### PR TITLE
fix: test dApp for custodial & non-custodial registration

### DIFF
--- a/docs/testing-with-middleware.md
+++ b/docs/testing-with-middleware.md
@@ -1,0 +1,220 @@
+# Testing the Canton Snap with Middleware (Local Development)
+
+This guide covers what the test dApp currently supports. See the [TODO](#todo--future-work) section for flows not yet implemented.
+
+---
+
+## Architecture Overview
+
+The Canton Snap is a **pure signing oracle** — it never talks to the middleware directly. The test dApp orchestrates between the two:
+
+```
+Browser (test dApp)
+    │
+    ├── window.ethereum.request(wallet_invokeSnap, ...) ──► MetaMask Flask
+    │                                                            │
+    │                                                       Canton Snap
+    │                                                       (key derivation
+    │                                                        + signing)
+    │
+    └── fetch(http://localhost:8081/...) ──────────────────► Middleware API
+                                                                  │
+                                                             Canton Ledger
+                                                             (gRPC)
+```
+
+---
+
+## Prerequisites
+
+### 1. MetaMask Flask
+
+You **cannot** use regular MetaMask. You need **MetaMask Flask** — the developer build that allows installing unaudited local snaps.
+
+- Download: https://metamask.io/flask/
+- Install in a **separate browser profile** — Flask and regular MetaMask conflict in the same profile.
+
+### 2. Node.js
+
+```bash
+node --version   # v18 or higher
+```
+
+### 3. Middleware running
+
+The middleware repo is at `../canton-middleware`. Start it manually (Canton ledger + PostgreSQL + API server). Verify:
+
+```bash
+curl http://localhost:8081/health
+# Expected: OK
+```
+
+---
+
+## Starting the Dev Servers
+
+```bash
+# Install dependencies (first time only)
+npm install
+
+# Start snap server (port 4001) + dApp server (port 3000) together
+npm run serve
+
+# Or start individually:
+npm run serve:snap   # snap only — http://localhost:4001
+npm run serve:dapp   # dApp only — http://localhost:3000
+```
+
+Open the test dApp at **http://localhost:3000** (not `file://` — MetaMask won't inject into file:// pages).
+
+---
+
+## Step 1: Install the Snap
+
+1. Open http://localhost:3000 in the browser where MetaMask Flask is installed.
+2. Click **"Install / Connect Snap"**.
+3. MetaMask Flask prompts to add the Canton Network Snap — review permissions and click **Install**.
+
+The snap ID is `local:http://localhost:4001`. If you previously installed the snap at a different port, go to MetaMask Flask → Settings → Snaps → Remove it first, then reinstall.
+
+---
+
+## Step 2: Custodial Registration
+
+The middleware generates and stores the Canton signing key on your behalf. One click.
+
+1. Click **"Register (Custodial)"**.
+2. MetaMask shows a **Sign Message** dialog for `register:<timestamp>` — approve it.
+3. The middleware allocates a Canton party and returns:
+
+```json
+{
+  "party": "user_ab12cd34::...",
+  "fingerprint": "0x...",
+  "key_mode": "custodial"
+}
+```
+
+If you see a green **"Already registered"** banner, this address already has a Canton party — skip to Step 4.
+
+---
+
+## Step 3: Non-Custodial Registration (Snap)
+
+You control the signing key — it lives in MetaMask Flask, never on the middleware. Run all 4 sub-steps in order.
+
+### Step 3.1 — Get Public Key
+
+Click **"1. Get Public Key"**. MetaMask Flask shows a confirmation dialog. Approve.
+
+The snap derives a secp256k1 key from your seed and returns the compressed public key, SPKI DER encoding, and fingerprint.
+
+### Step 3.2 — Prepare Topology
+
+Click **"2. Prepare Topology"**. This:
+- Signs `register:<timestamp>` with your MetaMask EVM key (`personal_sign`)
+- POSTs to `/register/prepare-topology` with your compressed public key
+- Receives a `topology_hash` (34-byte Canton multihash) and `registration_token`
+
+If this step returns a green **"Already registered"** banner, skip the remaining sub-steps.
+
+### Step 3.3 — Sign Topology
+
+Click **"3. Sign Topology"**. MetaMask Flask shows the topology hash for confirmation. Approve.
+
+The snap SHA-256 hashes the multihash bytes, then signs the resulting 32-byte digest with ECDSA — matching Canton's `EC_DSA_SHA_256` signing spec.
+
+### Step 3.4 — Complete Registration
+
+Click **"4. Complete Registration"**. The dApp submits all collected pieces to `/register`:
+
+```json
+{
+  "signature": "0x...",
+  "message": "register:<timestamp>",
+  "key_mode": "external",
+  "canton_public_key": "<compressed pubkey hex>",
+  "registration_token": "<uuid>",
+  "topology_signature": "<DER signature hex>"
+}
+```
+
+A successful response means your Canton party is live with your snap-derived key as the sole signer.
+
+---
+
+## Step 4: Snap Crypto — Individual Method Testing
+
+These sections test snap RPC methods in isolation, independent of the middleware.
+
+| Section | Snap method | What it tests |
+|---|---|---|
+| `canton_getPublicKey` | `canton_getPublicKey` | Key derivation, SPKI encoding, fingerprint |
+| `canton_getFingerprint` | `canton_getFingerprint` | Fingerprint only, no dialog |
+| `canton_signHash` | `canton_signHash` | Signs a 32-byte hash with transaction metadata display |
+
+These are useful for verifying the snap's crypto output in isolation — e.g. feeding in a hash from a middleware response manually and confirming the DER signature format.
+
+---
+
+## Running Snap Unit Tests
+
+```bash
+npm test
+# 28 cross-validation tests against Go-generated test vectors
+# Verifies: key derivation, SPKI DER, fingerprint, DER signatures
+```
+
+---
+
+## Current Limitations
+
+**Cannot install in regular MetaMask** — The snap is not published to npm. It only works via `local:http://localhost:4001` in MetaMask Flask. Publishing requires an npm release and MetaMask's snap review process.
+
+**MetaMask Flask only** — Flask cannot coexist with regular MetaMask in the same browser profile. Use a dedicated profile.
+
+**Each tester runs their own snap server** — The `local:` snap ID is tied to localhost. Teammates cannot share one snap server.
+
+**Middleware URL is configurable but no staging environment exists** — The dApp Config section lets you change the middleware URL, but there is no shared testnet or staging deployment yet.
+
+**Key index must match registration** — All snap calls must use the same key index used during registration (default: `0`). A different index derives a different key and the middleware will reject the signature.
+
+---
+
+## TODO / Future Work
+
+The following flows are **not yet implemented** in the test dApp (tracked in [issue #5](https://github.com/ChainSafe/canton-snap/issues/5)):
+
+- **Check registration status** — No `GET /user` endpoint on the middleware yet. The dApp detects already-registered state reactively (409 on registration), but cannot proactively check status on load.
+- **Token transfer flow** — Prepare transfer (`POST /api/v2/transfer/prepare`), sign the returned hash with `canton_signHash`, and execute (`POST /api/v2/transfer/execute`). The snap method works but the dApp has no UI wiring for the middleware prepare/execute round-trip.
+- **Balance display** — No UI to query a registered user's DEMO/PROMPT balance from the middleware.
+- **Token minting** — No faucet/mint UI. Currently requires running middleware scripts manually:
+  ```bash
+  cd ../canton-middleware
+  go run scripts/testing/mint-tokens.go --address <evm-address> --amount 1000 --token DEMO
+  ```
+- **End-to-end automated test** — The 9-step integration flow (registration → mint → transfer → verify balance) is not scripted. Crypto correctness is verified by unit tests; the full round-trip needs an automated integration test suite.
+
+---
+
+## Quick Reference
+
+| | |
+|---|---|
+| Test dApp | http://localhost:3000 |
+| Snap server | http://localhost:4001 |
+| Snap ID | `local:http://localhost:4001` |
+| Middleware API | http://localhost:8081 |
+| Middleware health | `GET http://localhost:8081/health` |
+
+| Middleware endpoint | Purpose |
+|---|---|
+| `POST /register` | Custodial or non-custodial registration |
+| `POST /register/prepare-topology` | Step 1 of non-custodial registration |
+
+| Snap method | Dialog | Purpose |
+|---|---|---|
+| `canton_getPublicKey` | Yes | Key derivation + SPKI + fingerprint |
+| `canton_signTopology` | Yes | SHA-256 + ECDSA sign of Canton topology multihash |
+| `canton_signHash` | Yes | ECDSA sign of 32-byte pre-hashed digest |
+| `canton_getFingerprint` | No | Fingerprint lookup only |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "license": "MIT",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "concurrently": "^9.0.0"
+      }
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -6290,6 +6293,47 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -10651,6 +10695,16 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10874,6 +10928,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -11653,6 +11720,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
   ],
   "scripts": {
     "build": "npm -w packages/snap run build",
+    "serve:snap": "npm -w packages/snap run serve",
+    "serve:dapp": "npx serve packages/test-dapp -p 3000 --no-clipboard",
+    "serve": "concurrently -n snap,dapp -c cyan,magenta \"npm run serve:snap\" \"npm run serve:dapp\"",
     "test": "npm -w packages/snap run test:crypto",
     "test:snap": "npm -w packages/snap run test"
+  },
+  "devDependencies": {
+    "concurrently": "^9.0.0"
   }
 }

--- a/packages/snap/snap.config.ts
+++ b/packages/snap/snap.config.ts
@@ -12,7 +12,7 @@ const config: SnapConfig = {
     buffer: false,
   },
   server: {
-    port: 8080,
+    port: 4001,
   },
 };
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Canton Network key management and transaction signing for MetaMask",
   "proposedName": "Canton Snap",
   "source": {
-    "shasum": "zZ+vPN4ilgaGZrtzAQrv+zhzIsEVrwB34BWYpMwdc9Y=",
+    "shasum": "bPhuBgdm//5Zf4bONlaiG2XSANTi0EKcb7aJktu9azs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
+import { sha256 } from "@noble/hashes/sha256";
 import { deriveCantonKey } from "./keyDerivation";
 import { compressedPubKeyToSPKIDer } from "./spki";
 import { fingerprintFromSPKI } from "./fingerprint";
@@ -95,10 +96,14 @@ async function handleSignTopology(params: SignTopologyParams): Promise<SignRespo
   }
 
   const hash = stripHexPrefix(params.hash);
-  const hashBytes = hexToBytes(hash);
-  if (hashBytes.length === 0) {
+  const multiHashBytes = hexToBytes(hash);
+  if (multiHashBytes.length === 0) {
     throw new Error("hash must not be empty");
   }
+
+  // Canton's EC_DSA_SHA_256 algorithm: the signer hashes the raw MultiHash
+  // before signing, matching CantonKeyPair.SignDER() in the Go SDK.
+  const hashBytes = sha256(multiHashBytes);
 
   const { privateKey, compressedPubKey } = await deriveCantonKey(params.keyIndex ?? 0);
 

--- a/packages/test-dapp/index.html
+++ b/packages/test-dapp/index.html
@@ -5,24 +5,39 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Canton Snap Test dApp</title>
   <style>
-    body { font-family: monospace; max-width: 800px; margin: 40px auto; padding: 0 20px; background: #1a1a2e; color: #eee; }
+    body { font-family: monospace; max-width: 860px; margin: 40px auto; padding: 0 20px; background: #1a1a2e; color: #eee; }
     h1 { color: #e94560; }
     h2 { color: #0f3460; background: #e94560; padding: 8px 12px; margin-top: 30px; }
+    h3 { color: #e94560; margin: 18px 0 6px; }
     button { background: #0f3460; color: #eee; border: 1px solid #e94560; padding: 10px 20px; cursor: pointer; margin: 5px 0; font-family: monospace; font-size: 14px; }
     button:hover { background: #e94560; }
-    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    button:disabled { opacity: 0.4; cursor: not-allowed; }
     .result { background: #16213e; padding: 12px; margin: 10px 0; border-left: 3px solid #e94560; word-break: break-all; white-space: pre-wrap; font-size: 13px; }
     .error { border-left-color: #ff6b6b; color: #ff6b6b; }
     .success { border-left-color: #51cf66; }
     input { background: #16213e; color: #eee; border: 1px solid #0f3460; padding: 8px; font-family: monospace; width: 100%; box-sizing: border-box; margin: 4px 0; }
     label { display: block; margin-top: 10px; color: #aaa; }
     .row { display: flex; gap: 10px; align-items: center; }
+    .step { border-left: 3px solid #0f3460; padding-left: 14px; margin: 12px 0; }
+    .step-label { color: #aaa; font-size: 12px; margin-bottom: 4px; }
   </style>
 </head>
 <body>
   <h1>Canton Snap Test dApp</h1>
   <p>Local testing interface for the Canton MetaMask Snap.</p>
 
+  <div id="noMetaMaskBanner" style="display:none;background:#3d0000;border:2px solid #ff6b6b;padding:16px;margin-bottom:20px;color:#ff6b6b;">
+    <strong>MetaMask not detected.</strong><br><br>
+    Two common causes:
+    <ol style="margin:8px 0 0 0;padding-left:20px;color:#ffaaaa;">
+      <li>You opened this file as <code>file://</code> — MetaMask does not inject into file:// pages.<br>
+          Fix: <code>npx serve packages/test-dapp</code> and open <code>http://localhost:3000</code></li>
+      <li>MetaMask Flask is not installed in this browser.<br>
+          Fix: Install <a href="https://metamask.io/flask/" style="color:#ff9999;">MetaMask Flask</a> (the developer build — required for local snaps).</li>
+    </ol>
+  </div>
+
+  <!-- ── Connection ───────────────────────────────────────────────── -->
   <h2>Connection</h2>
   <div class="row">
     <button id="connectBtn" onclick="connectSnap()">Install / Connect Snap</button>
@@ -30,6 +45,59 @@
   </div>
   <div id="connectResult" class="result" hidden></div>
 
+  <!-- ── Config ───────────────────────────────────────────────────── -->
+  <h2>Config</h2>
+  <label>Middleware URL: <input id="middlewareUrl" value="http://localhost:8081"></label>
+  <label>Key Index (used across all flows): <input id="globalKeyIndex" type="number" value="0" min="0" style="width:80px"></label>
+
+  <!-- ── Custodial Registration ──────────────────────────────────── -->
+  <h2>Custodial Registration</h2>
+  <p style="color:#aaa;font-size:13px;">Middleware generates and stores the Canton key on your behalf. Single step.</p>
+
+  <div id="custAlreadyBanner" style="display:none;background:#0a2e0a;border:2px solid #51cf66;padding:14px;margin:10px 0;color:#51cf66;">
+    <strong>Already registered.</strong> This address already has a custodial Canton party.
+    <div id="custAlreadyDetails" style="margin-top:8px;font-size:12px;color:#aaffaa;word-break:break-all;"></div>
+  </div>
+
+  <button id="custRegBtn" onclick="custRegister()">Register (Custodial)</button>
+  <div id="custRegResult" class="result" hidden></div>
+
+  <!-- ── Registration Flow ────────────────────────────────────────── -->
+  <h2>Registration Flow (Non-Custodial)</h2>
+  <p style="color:#aaa;font-size:13px;">Run steps 1–4 in order. Each step unlocks the next.</p>
+
+  <div id="regAlreadyBanner" style="display:none;background:#0a2e0a;border:2px solid #51cf66;padding:14px;margin:10px 0;color:#51cf66;">
+    <strong>Already registered.</strong> This address has an active Canton party — no need to re-register.
+    <div id="regAlreadyDetails" style="margin-top:8px;font-size:12px;color:#aaffaa;word-break:break-all;"></div>
+  </div>
+
+  <div id="regSteps">
+    <div class="step">
+      <div class="step-label">Step 1 — Get public key from snap</div>
+      <button onclick="regStep1()">1. Get Public Key</button>
+      <div id="reg1Result" class="result" hidden></div>
+    </div>
+
+    <div class="step">
+      <div class="step-label">Step 2 — Sign registration message &amp; prepare topology on middleware</div>
+      <button id="reg2Btn" onclick="regStep2()" disabled>2. Prepare Topology</button>
+      <div id="reg2Result" class="result" hidden></div>
+    </div>
+
+    <div class="step">
+      <div class="step-label">Step 3 — Sign topology hash with snap</div>
+      <button id="reg3Btn" onclick="regStep3()" disabled>3. Sign Topology</button>
+      <div id="reg3Result" class="result" hidden></div>
+    </div>
+
+    <div class="step">
+      <div class="step-label">Step 4 — Submit registration to middleware</div>
+      <button id="reg4Btn" onclick="regStep4()" disabled>4. Complete Registration</button>
+      <div id="reg4Result" class="result" hidden></div>
+    </div>
+  </div>
+
+  <!-- ── Individual Snap Methods ──────────────────────────────────── -->
   <h2>canton_getPublicKey</h2>
   <label>Key Index: <input id="getPubKeyIndex" type="number" value="0" min="0" style="width:80px"></label>
   <button onclick="getPublicKey()">Get Public Key</button>
@@ -49,13 +117,35 @@
   <button onclick="signHash()">Sign Hash</button>
   <div id="signResult" class="result" hidden></div>
 
-  <h2>canton_signTopology (Registration)</h2>
-  <label>Topology Hash (hex): <input id="topoHashInput" placeholder="topology hash from prepare-topology"></label>
-  <button onclick="signTopology()">Sign Topology</button>
-  <div id="topoResult" class="result" hidden></div>
-
   <script>
-    const SNAP_ID = 'local:http://localhost:8080';
+    const SNAP_ID = 'local:http://localhost:4001';
+
+    // State carried between registration steps
+    const reg = {};
+
+    function getEthereum() {
+      if (typeof window.ethereum === 'undefined') {
+        throw new Error(
+          'MetaMask not found. Open this page over HTTP (not file://) and ensure MetaMask Flask is installed.'
+        );
+      }
+      return window.ethereum;
+    }
+
+    function middlewareUrl() {
+      return document.getElementById('middlewareUrl').value.replace(/\/$/, '');
+    }
+
+    function globalKeyIndex() {
+      return parseInt(document.getElementById('globalKeyIndex').value) || 0;
+    }
+
+    window.addEventListener('load', () => {
+      if (typeof window.ethereum === 'undefined') {
+        document.getElementById('noMetaMaskBanner').style.display = 'block';
+        document.getElementById('connectBtn').disabled = true;
+      }
+    });
 
     function show(id, data, isError = false) {
       const el = document.getElementById(id);
@@ -64,9 +154,36 @@
       el.textContent = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
     }
 
+    class AlreadyRegisteredError extends Error {
+      constructor(details) { super('already_registered'); this.details = details; }
+    }
+
+    async function mwFetch(path, body) {
+      const resp = await fetch(`${middlewareUrl()}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const text = await resp.text();
+      if (resp.status === 409) throw new AlreadyRegisteredError(text);
+      if (!resp.ok) throw new Error(`${resp.status}: ${text}`);
+      return JSON.parse(text);
+    }
+
+    function showAlreadyRegistered(details) {
+      document.getElementById('regSteps').style.display = 'none';
+      const banner = document.getElementById('regAlreadyBanner');
+      banner.style.display = 'block';
+      if (details) {
+        document.getElementById('regAlreadyDetails').textContent = details;
+      }
+    }
+
+    // ── Snap connection ───────────────────────────────────────────────
+
     async function connectSnap() {
       try {
-        await window.ethereum.request({
+        await getEthereum().request({
           method: 'wallet_requestSnaps',
           params: { [SNAP_ID]: {} },
         });
@@ -78,11 +195,121 @@
     }
 
     async function invokeSnap(method, params) {
-      return window.ethereum.request({
+      return getEthereum().request({
         method: 'wallet_invokeSnap',
         params: { snapId: SNAP_ID, request: { method, params } },
       });
     }
+
+    // ── Registration flow ─────────────────────────────────────────────
+
+    async function regStep1() {
+      try {
+        const result = await invokeSnap('canton_getPublicKey', { keyIndex: globalKeyIndex() });
+        reg.compressedPubKey = result.compressedPubKey;
+        reg.spkiDer = result.spkiDer;
+        reg.fingerprint = result.fingerprint;
+        show('reg1Result', result);
+        document.getElementById('reg2Btn').disabled = false;
+      } catch (e) {
+        show('reg1Result', e.message, true);
+      }
+    }
+
+    async function regStep2() {
+      try {
+        const accounts = await getEthereum().request({ method: 'eth_requestAccounts' });
+        reg.evmAddress = accounts[0];
+
+        const timestamp = Math.floor(Date.now() / 1000);
+        reg.message = `register:${timestamp}`;
+
+        // personal_sign expects hex-encoded UTF-8 string
+        const msgHex = '0x' + Array.from(new TextEncoder().encode(reg.message))
+          .map(b => b.toString(16).padStart(2, '0')).join('');
+
+        reg.signature = await getEthereum().request({
+          method: 'personal_sign',
+          params: [msgHex, reg.evmAddress],
+        });
+
+        const data = await mwFetch('/register/prepare-topology', {
+          signature: reg.signature,
+          message: reg.message,
+          canton_public_key: reg.compressedPubKey,
+        });
+
+        reg.topologyHash = data.topology_hash;
+        reg.registrationToken = data.registration_token;
+
+        show('reg2Result', data);
+        document.getElementById('reg3Btn').disabled = false;
+      } catch (e) {
+        if (e instanceof AlreadyRegisteredError) { showAlreadyRegistered(e.details); return; }
+        show('reg2Result', e.message, true);
+      }
+    }
+
+    async function regStep3() {
+      try {
+        const result = await invokeSnap('canton_signTopology', { hash: reg.topologyHash });
+        reg.topologySignature = result.derSignature;
+        show('reg3Result', result);
+        document.getElementById('reg4Btn').disabled = false;
+      } catch (e) {
+        show('reg3Result', e.message, true);
+      }
+    }
+
+    async function regStep4() {
+      try {
+        const data = await mwFetch('/register', {
+          signature: reg.signature,
+          message: reg.message,
+          key_mode: 'external',
+          canton_public_key: reg.compressedPubKey,
+          registration_token: reg.registrationToken,
+          topology_signature: reg.topologySignature,
+        });
+        show('reg4Result', data);
+      } catch (e) {
+        if (e instanceof AlreadyRegisteredError) { showAlreadyRegistered(e.details); return; }
+        show('reg4Result', e.message, true);
+      }
+    }
+
+    // ── Custodial registration ────────────────────────────────────────
+
+    async function custRegister() {
+      try {
+        const accounts = await getEthereum().request({ method: 'eth_requestAccounts' });
+        const address = accounts[0];
+
+        const timestamp = Math.floor(Date.now() / 1000);
+        const message = `register:${timestamp}`;
+        const msgHex = '0x' + Array.from(new TextEncoder().encode(message))
+          .map(b => b.toString(16).padStart(2, '0')).join('');
+
+        const signature = await getEthereum().request({
+          method: 'personal_sign',
+          params: [msgHex, address],
+        });
+
+        const data = await mwFetch('/register', { signature, message });
+        show('custRegResult', data);
+      } catch (e) {
+        if (e instanceof AlreadyRegisteredError) {
+          document.getElementById('custRegBtn').disabled = true;
+          const banner = document.getElementById('custAlreadyBanner');
+          banner.style.display = 'block';
+          document.getElementById('custAlreadyDetails').textContent = e.details;
+          return;
+        }
+        show('custRegResult', e.message, true);
+      }
+    }
+
+    // ── Individual snap methods ───────────────────────────────────────
 
     async function getPublicKey() {
       try {
@@ -120,15 +347,6 @@
       }
     }
 
-    async function signTopology() {
-      try {
-        const hash = document.getElementById('topoHashInput').value;
-        const result = await invokeSnap('canton_signTopology', { hash });
-        show('topoResult', result);
-      } catch (e) {
-        show('topoResult', e.message, true);
-      }
-    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Fix `canton_signTopology`**: SHA-256 hash the raw Canton MultiHash before signing, correctly implementing the `EC_DSA_SHA_256` spec (`CantonKeyPair.SignDER` behaviour in the Go SDK). Previously the snap passed the 34-byte MultiHash directly to ECDSA, which fails with _"hash must be 32 bytes"_.
- **Test dApp — non-custodial registration** (4-step sequential flow): get public key → prepare topology → sign topology → complete registration
- **Test dApp — custodial registration**: single-click EIP-191 sign + POST `/register`
- **Already-registered (409) handling**: hides steps and shows a green status banner instead of an error
- **MetaMask detection banner**: actionable instructions when `window.ethereum` is undefined (file:// or Flask not installed)
- **Config inputs**: middleware URL and key index configurable in the UI
- **Dev commands**: `serve:snap`, `serve:dapp`, and `serve` (both concurrently via `concurrently`)
- **Docs**: `docs/testing-with-middleware.md` — setup guide, known limitations, and TODO section for future flows

## Test plan

- [ ] `npm run build` passes with no errors
- [ ] Snap installs in MetaMask Flask via `local:http://localhost:4001`
- [ ] Custodial registration: single click → MetaMask `personal_sign` prompt → middleware POST → success result shown
- [ ] Non-custodial registration: steps 1–4 unlock sequentially, topology signed correctly, final registration succeeds
- [ ] Already-registered address: 409 response shows green banner, hides step buttons
- [ ] `canton_getPublicKey` and `canton_getFingerprint` panels return correct results
- [ ] `canton_signHash` panel produces a valid DER signature
