### PR TITLE
feat: dApp user profile dashboard

### DIFF
--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -124,7 +124,7 @@ export default function App() {
           const addr = await mm.connect();
           if (!addr) return;
 
-          // Get or create a session signature for authenticating GET /user.
+          // Get or create a session signature for authenticating GET /profile.
           // If the server rejects the cached signature as expired, clear it and re-sign once.
           const freshSign = async () => {
             const message = `login:${addr.toLowerCase()}:${Math.floor(Date.now() / 1000)}`;

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -1,12 +1,16 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useMetaMask } from "./hooks/useMetaMask";
 import { useRegistration } from "./hooks/useRegistration";
 import { DEFAULT_NETWORK, getNetwork, type NetworkId } from "./lib/config";
+import { personalSign } from "./lib/ethereum";
+import { getUser, type UserProfile } from "./lib/middleware";
+import { getSession, storeSession, clearAllSessions } from "./lib/session";
 import { LandingPage } from "./pages/LandingPage";
 import { RegistrationChoicePage } from "./pages/RegistrationChoicePage";
 import { CustodialRegistrationPage } from "./pages/CustodialRegistrationPage";
 import { NonCustodialRegistrationPage } from "./pages/NonCustodialRegistrationPage";
 import { RegistrationDonePage } from "./pages/RegistrationDonePage";
+import { DashboardProfilePage } from "./pages/DashboardProfilePage";
 
 type Page =
   | "landing"
@@ -21,10 +25,34 @@ export default function App() {
   const [page, setPage] = useState<Page>("landing");
   const [mode, setMode] = useState<"custodial" | "noncustodial">("custodial");
   const [network, setNetwork] = useState<NetworkId>(DEFAULT_NETWORK);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const autoConnectAttempted = useRef(false);
 
   const mm = useMetaMask();
   const reg = useRegistration(getNetwork(network).middlewareUrl);
   const { registerCustodial, sign } = reg;
+
+  // Auto-reconnect on refresh: if MetaMask already has an account and we have a
+  // cached session signature, skip the landing page and go straight to dashboard.
+  useEffect(() => {
+    if (mm.autoConnecting) return;
+    if (autoConnectAttempted.current) return;
+    autoConnectAttempted.current = true;
+
+    if (!mm.address) return;
+
+    const session = getSession(mm.address);
+    if (!session) return;
+
+    getUser(getNetwork(network).middlewareUrl, mm.address, session.signature, session.message).then(
+      (existing) => {
+        if (existing) {
+          setProfile(existing);
+          setPage("dashboard");
+        }
+      },
+    );
+  }, [mm.autoConnecting, mm.address, network]);
 
   const handleRegisterCustodial = useCallback(async () => {
     const done = await registerCustodial(mm.address ?? "");
@@ -38,6 +66,8 @@ export default function App() {
 
   function handleDisconnect() {
     mm.disconnect();
+    setProfile(null);
+    clearAllSessions();
     setPage("landing");
   }
 
@@ -53,6 +83,7 @@ export default function App() {
 
   const address = mm.address ?? "";
   const netProps = { network, onNetworkChange: setNetwork };
+  const snapInstalled = reg.snap.installed || reg.snap.alreadyInstalled;
 
   if (page === "landing") {
     return (
@@ -61,8 +92,35 @@ export default function App() {
         connecting={mm.connecting}
         error={mm.error}
         onConnect={async () => {
-          await mm.connect();
-          setPage("registration-choice");
+          const addr = await mm.connect();
+          if (!addr) return;
+
+          // Get or create a session signature for authenticating GET /user.
+          let session = getSession(addr);
+          if (!session) {
+            const message = `login:${addr.toLowerCase()}`;
+            try {
+              const signature = await personalSign(message, addr);
+              storeSession(addr, message, signature);
+              session = { message, signature };
+            } catch {
+              // User rejected signing — stay on landing so they can try again.
+              return;
+            }
+          }
+
+          const existing = await getUser(
+            getNetwork(network).middlewareUrl,
+            addr,
+            session.signature,
+            session.message,
+          );
+          if (existing) {
+            setProfile(existing);
+            setPage("dashboard");
+          } else {
+            setPage("registration-choice");
+          }
         }}
       />
     );
@@ -145,45 +203,30 @@ export default function App() {
         fingerprint={done?.fingerprint ?? ""}
         snapInstalled={mode === "noncustodial" && reg.snap.installed}
         wasAlreadyRegistered={reg.wasAlreadyRegistered}
-        onDashboard={() => setPage("dashboard")}
+        onDashboard={() => {
+          if (done) {
+            setProfile({
+              cantonPartyId: done.cantonPartyId,
+              fingerprint: done.fingerprint,
+              keyMode: mode === "noncustodial" ? "external" : "custodial",
+            });
+          }
+          setPage("dashboard");
+        }}
         onDisconnect={handleDisconnect}
       />
     );
   }
 
-  if (page === "dashboard") {
+  if (page === "dashboard" && profile) {
     return (
-      <div
-        style={{
-          minHeight: "100vh",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flexDirection: "column",
-          gap: 16,
-          color: "var(--text-secondary)",
-          fontSize: 15,
-        }}
-      >
-        <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
-          <rect width="48" height="48" rx="12" fill="rgba(0,212,164,0.1)" />
-          <path
-            d="M14 28 L20 20 L26 24 L32 16"
-            stroke="#00d4a4"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        <p>Dashboard coming soon</p>
-        <button
-          className="btn btn-secondary"
-          style={{ fontSize: 13, padding: "8px 20px" }}
-          onClick={() => setPage("registration-choice")}
-        >
-          ← Back
-        </button>
-      </div>
+      <DashboardProfilePage
+        address={address}
+        {...netProps}
+        profile={profile}
+        snapInstalled={snapInstalled}
+        onDisconnect={handleDisconnect}
+      />
     );
   }
 

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useMetaMask } from "./hooks/useMetaMask";
 import { useRegistration } from "./hooks/useRegistration";
 import { DEFAULT_NETWORK, getNetwork, type NetworkId } from "./lib/config";
 import { personalSign } from "./lib/ethereum";
-import { getUser, type UserProfile } from "./lib/middleware";
-import { getSession, storeSession, clearAllSessions } from "./lib/session";
+import { getUser, SessionExpiredError, type UserProfile } from "./lib/middleware";
+import { getSession, storeSession, clearSession, clearAllSessions } from "./lib/session";
+import { Spinner } from "./components/Spinner";
 import { LandingPage } from "./pages/LandingPage";
 import { RegistrationChoicePage } from "./pages/RegistrationChoicePage";
 import { CustodialRegistrationPage } from "./pages/CustodialRegistrationPage";
@@ -26,7 +27,8 @@ export default function App() {
   const [mode, setMode] = useState<"custodial" | "noncustodial">("custodial");
   const [network, setNetwork] = useState<NetworkId>(DEFAULT_NETWORK);
   const [profile, setProfile] = useState<UserProfile | null>(null);
-  const autoConnectAttempted = useRef(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [reconnecting, setReconnecting] = useState(false);
 
   const mm = useMetaMask();
   const reg = useRegistration(getNetwork(network).middlewareUrl);
@@ -34,25 +36,38 @@ export default function App() {
 
   // Auto-reconnect on refresh: if MetaMask already has an account and we have a
   // cached session signature, skip the landing page and go straight to dashboard.
+  // Gating on page === "landing" naturally prevents re-runs once we've navigated
+  // away, while still allowing a re-check when the network changes on landing.
   useEffect(() => {
+    if (page !== "landing") return;
     if (mm.autoConnecting) return;
-    if (autoConnectAttempted.current) return;
-    autoConnectAttempted.current = true;
+    const addr = mm.address;
+    if (!addr) return;
 
-    if (!mm.address) return;
-
-    const session = getSession(mm.address);
+    const session = getSession(addr);
     if (!session) return;
 
-    getUser(getNetwork(network).middlewareUrl, mm.address, session.signature, session.message).then(
-      (existing) => {
+    setReconnecting(true);
+    getUser(getNetwork(network).middlewareUrl, addr, session.signature, session.message)
+      .then((existing) => {
         if (existing) {
           setProfile(existing);
           setPage("dashboard");
         }
-      },
-    );
-  }, [mm.autoConnecting, mm.address, network]);
+      })
+      .catch((e) => {
+        if (e instanceof SessionExpiredError) clearSession(addr);
+        // stay on landing in all error cases; user re-connects manually
+      })
+      .finally(() => setReconnecting(false));
+  }, [page, mm.autoConnecting, mm.address, network]);
+
+  // Guard: if we somehow reach the dashboard without a profile, reset to landing.
+  useEffect(() => {
+    if (page === "dashboard" && !profile) {
+      setPage("landing");
+    }
+  }, [page, profile]);
 
   const handleRegisterCustodial = useCallback(async () => {
     const done = await registerCustodial(mm.address ?? "");
@@ -84,42 +99,92 @@ export default function App() {
   const address = mm.address ?? "";
   const netProps = { network, onNetworkChange: setNetwork };
   const snapInstalled = reg.snap.installed || reg.snap.alreadyInstalled;
+  const snapVersion = reg.snap.version;
+
+  if (mm.autoConnecting || reconnecting) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+        }}
+      >
+        <Spinner />
+      </div>
+    );
+  }
 
   if (page === "landing") {
     return (
       <LandingPage
         detected={mm.detected}
         connecting={mm.connecting}
-        error={mm.error}
+        error={mm.error ?? connectError}
         onConnect={async () => {
+          setConnectError(null);
           const addr = await mm.connect();
           if (!addr) return;
 
           // Get or create a session signature for authenticating GET /user.
+          // If the server rejects the cached signature as expired, clear it and re-sign once.
+          const freshSign = async () => {
+            const message = `login:${addr.toLowerCase()}:${Math.floor(Date.now() / 1000)}`;
+            const signature = await personalSign(message, addr);
+            storeSession(addr, message, signature);
+            return { message, signature };
+          };
+
           let session = getSession(addr);
           if (!session) {
-            const message = `login:${addr.toLowerCase()}`;
             try {
-              const signature = await personalSign(message, addr);
-              storeSession(addr, message, signature);
-              session = { message, signature };
+              session = await freshSign();
             } catch {
-              // User rejected signing — stay on landing so they can try again.
-              return;
+              return; // user rejected signing
             }
           }
 
-          const existing = await getUser(
-            getNetwork(network).middlewareUrl,
-            addr,
-            session.signature,
-            session.message,
-          );
-          if (existing) {
-            setProfile(existing);
-            setPage("dashboard");
-          } else {
-            setPage("registration-choice");
+          try {
+            const existing = await getUser(
+              getNetwork(network).middlewareUrl,
+              addr,
+              session.signature,
+              session.message,
+            );
+            if (existing) {
+              setProfile(existing);
+              setPage("dashboard");
+            } else {
+              setPage("registration-choice");
+            }
+          } catch (e) {
+            if (e instanceof SessionExpiredError) {
+              clearSession(addr);
+              try {
+                session = await freshSign();
+              } catch {
+                return; // user rejected re-signing
+              }
+              try {
+                const existing = await getUser(
+                  getNetwork(network).middlewareUrl,
+                  addr,
+                  session.signature,
+                  session.message,
+                );
+                if (existing) {
+                  setProfile(existing);
+                  setPage("dashboard");
+                } else {
+                  setPage("registration-choice");
+                }
+              } catch (e2) {
+                setConnectError((e2 as Error).message);
+              }
+            } else {
+              setConnectError((e as Error).message);
+            }
           }
         }}
       />
@@ -219,12 +284,30 @@ export default function App() {
   }
 
   if (page === "dashboard" && profile) {
+    const handleNetworkChange = (id: NetworkId) => {
+      setNetwork(id);
+      if (!mm.address) return;
+      const session = getSession(mm.address);
+      if (!session) return;
+      void getUser(getNetwork(id).middlewareUrl, mm.address, session.signature, session.message)
+        .then((updated) => {
+          if (updated) {
+            setProfile(updated);
+          } else {
+            setProfile(null);
+            setPage("registration-choice");
+          }
+        })
+        .catch(() => {});
+    };
     return (
       <DashboardProfilePage
         address={address}
-        {...netProps}
+        network={network}
+        onNetworkChange={handleNetworkChange}
         profile={profile}
         snapInstalled={snapInstalled}
+        snapVersion={snapVersion}
         onDisconnect={handleDisconnect}
       />
     );

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -47,8 +47,12 @@ export default function App() {
     const session = getSession(addr);
     if (!session) return;
 
-    setReconnecting(true);
-    getUser(getNetwork(network).middlewareUrl, addr, session.signature, session.message)
+    // setReconnecting via .then() so it's in a callback, not the synchronous effect body.
+    Promise.resolve()
+      .then(() => setReconnecting(true))
+      .then(() =>
+        getUser(getNetwork(network).middlewareUrl, addr, session.signature, session.message),
+      )
       .then((existing) => {
         if (existing) {
           setProfile(existing);
@@ -61,13 +65,6 @@ export default function App() {
       })
       .finally(() => setReconnecting(false));
   }, [page, mm.autoConnecting, mm.address, network]);
-
-  // Guard: if we somehow reach the dashboard without a profile, reset to landing.
-  useEffect(() => {
-    if (page === "dashboard" && !profile) {
-      setPage("landing");
-    }
-  }, [page, profile]);
 
   const handleRegisterCustodial = useCallback(async () => {
     const done = await registerCustodial(mm.address ?? "");
@@ -266,7 +263,6 @@ export default function App() {
         {...netProps}
         cantonPartyId={done?.cantonPartyId ?? ""}
         fingerprint={done?.fingerprint ?? ""}
-        snapInstalled={mode === "noncustodial" && reg.snap.installed}
         wasAlreadyRegistered={reg.wasAlreadyRegistered}
         onDashboard={() => {
           if (done) {
@@ -308,6 +304,7 @@ export default function App() {
         profile={profile}
         snapInstalled={snapInstalled}
         snapVersion={snapVersion}
+        onInstallSnap={reg.snap.install}
         onDisconnect={handleDisconnect}
       />
     );

--- a/packages/dapp/src/components/TopBar.tsx
+++ b/packages/dapp/src/components/TopBar.tsx
@@ -8,7 +8,6 @@ import styles from "./TopBar.module.css";
 
 interface Props {
   address?: string | null;
-  snapInstalled?: boolean;
   network?: NetworkId;
   onNetworkChange?: (id: NetworkId) => void;
   onDisconnect?: () => void;
@@ -28,13 +27,7 @@ function Caret({ open }: { open: boolean }) {
   );
 }
 
-export function TopBar({
-  address,
-  snapInstalled,
-  network = "devnet",
-  onNetworkChange,
-  onDisconnect,
-}: Props) {
+export function TopBar({ address, network = "devnet", onNetworkChange, onDisconnect }: Props) {
   const [walletOpen, setWalletOpen] = useState(false);
   const [networkOpen, setNetworkOpen] = useState(false);
 
@@ -102,7 +95,6 @@ export function TopBar({
             {walletOpen && (
               <WalletMenu
                 address={address}
-                snapInstalled={snapInstalled}
                 onDisconnect={() => {
                   setWalletOpen(false);
                   onDisconnect?.();

--- a/packages/dapp/src/components/WalletMenu.module.css
+++ b/packages/dapp/src/components/WalletMenu.module.css
@@ -36,42 +36,10 @@
 
 .walletAddress {
   flex: 1;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
   overflow: hidden;
-}
-
-.addressTop {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--text-primary);
-}
-
-.addressBottom {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-secondary);
-  margin-top: 2px;
-}
-
-.snapRow {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
-}
-
-.snapInfo {
-  flex: 1;
-}
-
-.snapName {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.snapVersion {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-secondary);
-  margin-top: 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/packages/dapp/src/components/WalletMenu.tsx
+++ b/packages/dapp/src/components/WalletMenu.tsx
@@ -1,13 +1,13 @@
 import { CopyButton } from "./CopyButton";
+import { shortenAddress } from "../lib/ethereum";
 import styles from "./WalletMenu.module.css";
 
 interface Props {
   address: string;
-  snapInstalled?: boolean;
   onDisconnect: () => void;
 }
 
-export function WalletMenu({ address, snapInstalled, onDisconnect }: Props) {
+export function WalletMenu({ address, onDisconnect }: Props) {
   return (
     <div className="dropdown">
       <div className={styles.section}>
@@ -17,49 +17,10 @@ export function WalletMenu({ address, snapInstalled, onDisconnect }: Props) {
             <div className={styles.avatarRing} />
             <div className={styles.avatarDot} />
           </div>
-          <div className={styles.walletAddress}>
-            <p className={styles.addressTop}>{address.slice(0, 10)}</p>
-            <p className={styles.addressBottom}>…{address.slice(-24)}</p>
-          </div>
+          <p className={styles.walletAddress}>{shortenAddress(address, 6)}</p>
           <CopyButton text={address} />
         </div>
       </div>
-
-      {snapInstalled && (
-        <div className={styles.section}>
-          <p className="dropdown-section-label">CANTON SNAP</p>
-          <div className={`dropdown-row ${styles.snapRow}`}>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M12 2 L3 5 V12 C3 17 7 20 12 22 C17 20 21 17 21 12 V5 Z"
-                fill="rgba(0,212,164,0.12)"
-                stroke="#00d4a4"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M8 12 L11 15 L16 9"
-                stroke="#00d4a4"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-            <div className={styles.snapInfo}>
-              <p className={styles.snapName}>Installed</p>
-              <p className={styles.snapVersion}>v1.0.0 · npm:canton-snap</p>
-            </div>
-            <button
-              className="btn btn-ghost"
-              style={{ fontSize: 11, fontWeight: 600 }}
-              onClick={() => window.open("about:blank")}
-            >
-              Manage
-            </button>
-          </div>
-        </div>
-      )}
 
       <button className="btn btn-danger" onClick={onDisconnect}>
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">

--- a/packages/dapp/src/hooks/useMetaMask.ts
+++ b/packages/dapp/src/hooks/useMetaMask.ts
@@ -1,12 +1,13 @@
-import { useState, useCallback } from "react";
-import { requestAccounts } from "../lib/ethereum";
+import { useState, useCallback, useEffect } from "react";
+import { requestAccounts, getAccounts } from "../lib/ethereum";
 
 export interface MetaMaskState {
   detected: boolean;
   address: string | null;
   connecting: boolean;
+  autoConnecting: boolean;
   error: string | null;
-  connect: () => Promise<void>;
+  connect: () => Promise<string | null>;
   disconnect: () => void;
 }
 
@@ -14,16 +15,33 @@ export function useMetaMask(): MetaMaskState {
   const [detected] = useState(() => !!window.ethereum);
   const [address, setAddress] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
+  const [autoConnecting, setAutoConnecting] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const connect = useCallback(async () => {
+  useEffect(() => {
+    if (!window.ethereum) {
+      setAutoConnecting(false);
+      return;
+    }
+    getAccounts()
+      .then((accounts) => {
+        if (accounts[0]) setAddress(accounts[0]);
+      })
+      .catch(() => {})
+      .finally(() => setAutoConnecting(false));
+  }, []);
+
+  const connect = useCallback(async (): Promise<string | null> => {
     setConnecting(true);
     setError(null);
     try {
       const accounts = await requestAccounts();
-      setAddress(accounts[0] ?? null);
+      const addr = accounts[0] ?? null;
+      setAddress(addr);
+      return addr;
     } catch (e) {
       setError((e as Error).message);
+      return null;
     } finally {
       setConnecting(false);
     }
@@ -33,5 +51,5 @@ export function useMetaMask(): MetaMaskState {
     setAddress(null);
   }, []);
 
-  return { detected, address, connecting, error, connect, disconnect };
+  return { detected, address, autoConnecting, connecting, error, connect, disconnect };
 }

--- a/packages/dapp/src/hooks/useMetaMask.ts
+++ b/packages/dapp/src/hooks/useMetaMask.ts
@@ -15,14 +15,12 @@ export function useMetaMask(): MetaMaskState {
   const [detected] = useState(() => !!window.ethereum);
   const [address, setAddress] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
-  const [autoConnecting, setAutoConnecting] = useState(true);
+  // Start as true only when MetaMask is present; no need for a synchronous setState later.
+  const [autoConnecting, setAutoConnecting] = useState(() => !!window.ethereum);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!window.ethereum) {
-      setAutoConnecting(false);
-      return;
-    }
+    if (!window.ethereum) return; // already false from lazy initializer
     getAccounts()
       .then((accounts) => {
         if (accounts[0]) setAddress(accounts[0]);

--- a/packages/dapp/src/hooks/useRegistration.ts
+++ b/packages/dapp/src/hooks/useRegistration.ts
@@ -41,7 +41,7 @@ export function useRegistration(middlewareUrl: string): UseRegistrationReturn {
         const message = `register:${Math.floor(Date.now() / 1000)}`;
         const signature = await personalSign(message, address);
         const data = await apiRegisterCustodial(middlewareUrl, signature, message);
-        setResult({ cantonPartyId: data.canton_party_id, fingerprint: data.fingerprint });
+        setResult({ cantonPartyId: data.party, fingerprint: data.fingerprint });
         return true;
       } catch (e) {
         if (e instanceof AlreadyRegisteredError) {
@@ -80,7 +80,7 @@ export function useRegistration(middlewareUrl: string): UseRegistrationReturn {
           registration_token,
           topology_signature: topologySignature,
         });
-        setResult({ cantonPartyId: data.canton_party_id, fingerprint: data.fingerprint });
+        setResult({ cantonPartyId: data.party, fingerprint: data.fingerprint });
         return true;
       } catch (e) {
         if (e instanceof AlreadyRegisteredError) {

--- a/packages/dapp/src/hooks/useSnap.ts
+++ b/packages/dapp/src/hooks/useSnap.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { installSnap, isSnapInstalled, invokeSnap } from "../lib/ethereum";
+import { installSnap, getInstalledSnap, invokeSnap } from "../lib/ethereum";
 
 export interface SnapPublicKey {
   compressedPubKey: string;
@@ -11,6 +11,7 @@ export interface SnapState {
   installed: boolean;
   alreadyInstalled: boolean;
   installing: boolean;
+  version: string | null;
   error: string | null;
   install: () => Promise<boolean>;
   getPublicKey: (keyIndex?: number) => Promise<SnapPublicKey>;
@@ -21,14 +22,16 @@ export function useSnap(): SnapState {
   const [installed, setInstalled] = useState(false);
   const [alreadyInstalled, setAlreadyInstalled] = useState(false);
   const [installing, setInstalling] = useState(false);
+  const [version, setVersion] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Check if snap was installed from a previous session
   useEffect(() => {
-    isSnapInstalled().then((found) => {
-      if (found) {
+    getInstalledSnap().then((snap) => {
+      if (snap) {
         setInstalled(true);
         setAlreadyInstalled(true);
+        setVersion(snap.version);
       }
     });
   }, []);
@@ -39,6 +42,9 @@ export function useSnap(): SnapState {
     try {
       await installSnap();
       setInstalled(true);
+      getInstalledSnap().then((snap) => {
+        if (snap) setVersion(snap.version);
+      });
       return true;
     } catch (e) {
       setError((e as Error).message);
@@ -57,5 +63,14 @@ export function useSnap(): SnapState {
     return result.derSignature;
   }, []);
 
-  return { installed, alreadyInstalled, installing, error, install, getPublicKey, signTopology };
+  return {
+    installed,
+    alreadyInstalled,
+    installing,
+    version,
+    error,
+    install,
+    getPublicKey,
+    signTopology,
+  };
 }

--- a/packages/dapp/src/lib/ethereum.ts
+++ b/packages/dapp/src/lib/ethereum.ts
@@ -26,6 +26,10 @@ export async function requestAccounts(): Promise<string[]> {
   return getEthereum().request({ method: "eth_requestAccounts" }) as Promise<string[]>;
 }
 
+export async function getAccounts(): Promise<string[]> {
+  return getEthereum().request({ method: "eth_accounts" }) as Promise<string[]>;
+}
+
 export async function personalSign(message: string, address: string): Promise<string> {
   return getEthereum().request({
     method: "personal_sign",

--- a/packages/dapp/src/lib/ethereum.ts
+++ b/packages/dapp/src/lib/ethereum.ts
@@ -44,15 +44,15 @@ export async function installSnap(): Promise<void> {
   });
 }
 
-export async function isSnapInstalled(): Promise<boolean> {
+export async function getInstalledSnap(): Promise<{ version: string } | null> {
   try {
     const snaps = (await getEthereum().request({ method: "wallet_getSnaps" })) as Record<
       string,
-      unknown
+      { version: string }
     >;
-    return SNAP_ID in snaps;
+    return snaps[SNAP_ID] ?? null;
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -1,3 +1,31 @@
+export interface UserProfile {
+  cantonPartyId: string;
+  fingerprint: string;
+  keyMode: "custodial" | "external";
+}
+
+export async function getUser(
+  baseUrl: string,
+  address: string,
+  signature: string,
+  message: string,
+): Promise<UserProfile | null> {
+  try {
+    const params = new URLSearchParams({ address, signature, message });
+    const res = await fetch(`${baseUrl}/user?${params.toString()}`);
+    if (res.status === 404) return null;
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      cantonPartyId: data.canton_party ?? data.party,
+      fingerprint: data.fingerprint,
+      keyMode: data.key_mode === "external" ? "external" : "custodial",
+    };
+  } catch {
+    return null;
+  }
+}
+
 export class AlreadyRegisteredError extends Error {
   readonly details: string;
   constructor(details: string) {
@@ -36,7 +64,7 @@ function friendlyError(status: number, body: string): string {
 }
 
 export interface RegisterResult {
-  canton_party_id: string;
+  party: string;
   fingerprint: string;
 }
 

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -4,25 +4,41 @@ export interface UserProfile {
   keyMode: "custodial" | "external";
 }
 
+export class SessionExpiredError extends Error {
+  constructor() {
+    super("Session expired — please reconnect");
+  }
+}
+
 export async function getUser(
   baseUrl: string,
   address: string,
   signature: string,
   message: string,
 ): Promise<UserProfile | null> {
+  const res = await fetch(`${baseUrl}/user?address=${encodeURIComponent(address)}`, {
+    headers: { "X-Signature": signature, "X-Message": message },
+  });
+  if (res.status === 404) return null;
+  if (res.status === 401) throw new SessionExpiredError();
+  if (!res.ok) throw new Error(`Middleware error ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return {
+    cantonPartyId: data.canton_party,
+    fingerprint: data.fingerprint,
+    keyMode: data.key_mode === "external" ? "external" : "custodial",
+  };
+}
+
+export async function checkMiddlewareHealth(baseUrl: string): Promise<boolean> {
   try {
-    const params = new URLSearchParams({ address, signature, message });
-    const res = await fetch(`${baseUrl}/user?${params.toString()}`);
-    if (res.status === 404) return null;
-    if (!res.ok) return null;
-    const data = await res.json();
-    return {
-      cantonPartyId: data.canton_party ?? data.party,
-      fingerprint: data.fingerprint,
-      keyMode: data.key_mode === "external" ? "external" : "custodial",
-    };
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), 3000);
+    await fetch(`${baseUrl}/health`, { signal: controller.signal });
+    clearTimeout(id);
+    return true; // any HTTP response means the server is reachable
   } catch {
-    return null;
+    return false;
   }
 }
 

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -16,7 +16,7 @@ export async function getUser(
   signature: string,
   message: string,
 ): Promise<UserProfile | null> {
-  const res = await fetch(`${baseUrl}/user?address=${encodeURIComponent(address)}`, {
+  const res = await fetch(`${baseUrl}/profile?address=${encodeURIComponent(address)}`, {
     headers: { "X-Signature": signature, "X-Message": message },
   });
   if (res.status === 404) return null;

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -20,7 +20,12 @@ export async function getUser(
     headers: { "X-Signature": signature, "X-Message": message },
   });
   if (res.status === 404) return null;
-  if (res.status === 401) throw new SessionExpiredError();
+  if (res.status === 401) {
+    const body = await res.json().catch(() => ({}) as Record<string, unknown>);
+    const msg = typeof body.error === "string" ? body.error : "";
+    if (msg.includes("expired")) throw new SessionExpiredError();
+    throw new Error(msg || "Unauthorized");
+  }
   if (!res.ok) throw new Error(`Middleware error ${res.status}: ${await res.text()}`);
   const data = await res.json();
   return {

--- a/packages/dapp/src/lib/session.ts
+++ b/packages/dapp/src/lib/session.ts
@@ -1,0 +1,29 @@
+const SESSION_PREFIX = "canton_session_";
+
+export interface Session {
+  message: string;
+  signature: string;
+}
+
+export function storeSession(address: string, message: string, signature: string): void {
+  sessionStorage.setItem(
+    SESSION_PREFIX + address.toLowerCase(),
+    JSON.stringify({ message, signature }),
+  );
+}
+
+export function getSession(address: string): Session | null {
+  const raw = sessionStorage.getItem(SESSION_PREFIX + address.toLowerCase());
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Session;
+  } catch {
+    return null;
+  }
+}
+
+export function clearAllSessions(): void {
+  for (const key of Object.keys(sessionStorage)) {
+    if (key.startsWith(SESSION_PREFIX)) sessionStorage.removeItem(key);
+  }
+}

--- a/packages/dapp/src/lib/session.ts
+++ b/packages/dapp/src/lib/session.ts
@@ -22,6 +22,10 @@ export function getSession(address: string): Session | null {
   }
 }
 
+export function clearSession(address: string): void {
+  sessionStorage.removeItem(SESSION_PREFIX + address.toLowerCase());
+}
+
 export function clearAllSessions(): void {
   for (const key of Object.keys(sessionStorage)) {
     if (key.startsWith(SESSION_PREFIX)) sessionStorage.removeItem(key);

--- a/packages/dapp/src/pages/CustodialRegistrationPage.tsx
+++ b/packages/dapp/src/pages/CustodialRegistrationPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { Spinner } from "../components/Spinner";
@@ -42,7 +42,10 @@ export function CustodialRegistrationPage({
   onRegister,
   onDisconnect,
 }: Props) {
+  const triggered = useRef(false);
   useEffect(() => {
+    if (triggered.current) return;
+    triggered.current = true;
     void onRegister();
   }, [onRegister]);
 

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -1,0 +1,278 @@
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  background: #0d0f19;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebarLogo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 28px 24px 20px;
+}
+
+.sidebarDivider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 24px;
+}
+
+.sidebarNav {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 16px;
+  gap: 2px;
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: 40px;
+  padding: 0 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: default;
+  position: relative;
+  border: none;
+  background: transparent;
+  font-family: var(--font-sans);
+  width: 100%;
+  text-align: left;
+  transition: background 0.15s, color 0.15s;
+}
+
+.navItemActive {
+  background: rgba(0, 212, 164, 0.1);
+  color: var(--teal);
+  font-weight: 600;
+}
+
+.navItemActive::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 9px;
+  width: 3px;
+  height: 22px;
+  border-radius: 1.5px;
+  background: var(--teal);
+}
+
+/* ── Main area ── */
+.main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 40px 48px;
+  min-width: 0;
+}
+
+.mainHeader {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 48px;
+}
+
+.pillAnchor {
+  position: relative;
+}
+
+.pageTitle {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 32px;
+}
+
+/* ── Identity card ── */
+.identityCard {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 48px;
+  margin-bottom: 24px;
+}
+
+.sectionLabel {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  color: var(--text-muted);
+  margin-bottom: 14px;
+}
+
+.partyIdRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+.partyId {
+  font-family: var(--font-mono);
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--text-primary);
+  word-break: break-all;
+  line-height: 1.35;
+}
+
+.partyIdCont {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-muted);
+  word-break: break-all;
+  margin-top: 4px;
+}
+
+.fingerprintRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.fingerprint {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* ── Quick actions ── */
+.quickActions {
+  display: flex;
+  flex-direction: column;
+}
+
+.btnAction {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  border: none;
+  cursor: not-allowed;
+  font-family: var(--font-sans);
+  opacity: 0.6;
+  margin-top: 12px;
+  width: 100%;
+  text-align: left;
+}
+
+.btnSend {
+  composes: btnAction;
+  background: var(--teal-gradient);
+}
+
+.btnBridge {
+  composes: btnAction;
+  background: #232640;
+  border: 1px solid var(--border-muted) !important;
+}
+
+.btnActionTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0a0b14;
+  display: block;
+}
+
+.btnActionSub {
+  font-size: 11px;
+  color: rgba(10, 11, 20, 0.65);
+  display: block;
+  margin-top: 2px;
+}
+
+.btnBridgeTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: block;
+}
+
+.btnBridgeSub {
+  font-size: 11px;
+  color: var(--text-secondary);
+  display: block;
+  margin-top: 2px;
+}
+
+/* ── Connection card ── */
+.connectionCard {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+}
+
+.connectionCardTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 28px;
+}
+
+.connectionGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+}
+
+.connStatus {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  margin-bottom: 8px;
+}
+
+.connDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.connDotGreen {
+  background: var(--green);
+}
+
+.connDotAmber {
+  background: var(--amber);
+}
+
+.connLabel {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.connMeta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -276,3 +276,24 @@
   font-size: 11px;
   color: var(--text-muted);
 }
+
+.reinstallBtn {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--teal);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  letter-spacing: 0.3px;
+}
+
+.reinstallBtn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.reinstallBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -17,6 +17,7 @@ interface Props {
   profile: UserProfile;
   snapInstalled: boolean;
   snapVersion: string | null;
+  onInstallSnap: () => Promise<boolean>;
   onDisconnect: () => void;
 }
 
@@ -117,11 +118,13 @@ export function DashboardProfilePage({
   profile,
   snapInstalled,
   snapVersion,
+  onInstallSnap,
   onDisconnect,
 }: Props) {
   const [walletOpen, setWalletOpen] = useState(false);
   const [networkOpen, setNetworkOpen] = useState(false);
-  const [middlewareHealthy, setMiddlewareHealthy] = useState<boolean | null>(null);
+  const [reinstalling, setReinstalling] = useState(false);
+  const [healthCache, setHealthCache] = useState<{ url: string; healthy: boolean } | null>(null);
   const walletRef = useRef<HTMLDivElement>(null);
   const networkRef = useRef<HTMLDivElement>(null);
 
@@ -147,10 +150,18 @@ export function DashboardProfilePage({
 
   const currentNet = getNetwork(network);
   const isNonCustodial = profile.keyMode === "external";
+  // null while a check is in flight (URL doesn't match cached result yet)
+  const middlewareHealthy =
+    healthCache?.url === currentNet.middlewareUrl ? healthCache.healthy : null;
 
   useEffect(() => {
-    setMiddlewareHealthy(null);
-    checkMiddlewareHealth(currentNet.middlewareUrl).then(setMiddlewareHealthy);
+    let cancelled = false;
+    checkMiddlewareHealth(currentNet.middlewareUrl).then((healthy) => {
+      if (!cancelled) setHealthCache({ url: currentNet.middlewareUrl, healthy });
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [currentNet.middlewareUrl]);
 
   return (
@@ -221,7 +232,6 @@ export function DashboardProfilePage({
             {walletOpen && (
               <WalletMenu
                 address={address}
-                snapInstalled={snapInstalled}
                 onDisconnect={() => {
                   setWalletOpen(false);
                   onDisconnect();
@@ -338,6 +348,22 @@ export function DashboardProfilePage({
                     : "Not installed"}
                 </span>
               </div>
+              {!snapInstalled && isNonCustodial && (
+                <button
+                  className={styles.reinstallBtn}
+                  disabled={reinstalling}
+                  onClick={async () => {
+                    setReinstalling(true);
+                    try {
+                      await onInstallSnap();
+                    } finally {
+                      setReinstalling(false);
+                    }
+                  }}
+                >
+                  {reinstalling ? "Installing…" : "Re-install snap →"}
+                </button>
+              )}
             </div>
 
             <div>

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -1,0 +1,328 @@
+import { useState, useRef, useEffect } from "react";
+import { CopyButton } from "../components/CopyButton";
+import { Logo } from "../components/Logo";
+import { NetworkSwitcher } from "../components/NetworkSwitcher";
+import { WalletMenu } from "../components/WalletMenu";
+import { shortenAddress } from "../lib/ethereum";
+import { getNetwork, type NetworkId } from "../lib/config";
+import { cn } from "../lib/cn";
+import type { UserProfile } from "../lib/middleware";
+import styles from "./DashboardProfilePage.module.css";
+
+interface Props {
+  address: string;
+  network: NetworkId;
+  onNetworkChange: (id: NetworkId) => void;
+  profile: UserProfile;
+  snapInstalled: boolean;
+  onDisconnect: () => void;
+}
+
+function Caret({ open }: { open: boolean }) {
+  return (
+    <svg className="pill-caret" width="10" height="6" viewBox="0 0 10 6" fill="none">
+      <path
+        d={open ? "M1 5 L5 1 L9 5" : "M1 1 L5 5 L9 1"}
+        stroke="#a1a6c4"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ProfileIcon({ active }: { active?: boolean }) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      color={active ? "var(--teal)" : "currentColor"}
+    >
+      <circle cx="10" cy="7" r="3.5" stroke="currentColor" strokeWidth="1.6" />
+      <path
+        d="M3 17C3 13 6 11 10 11C14 11 17 13 17 17"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function BalancesIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <rect x="2" y="5" width="16" height="12" rx="2" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M2 9H18" stroke="currentColor" strokeWidth="1.6" />
+      <circle cx="14" cy="13" r="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function TransferIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M4 10H15M10 5L15 10L10 15"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function BridgeIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M3 8H15M12 5L15 8L12 11"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17 12H5M8 15L5 12L8 9"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ActivityIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+      <circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M10 6V10L13 12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+const NAV = [
+  { id: "profile", label: "Profile", Icon: ProfileIcon },
+  { id: "balances", label: "Balances", Icon: BalancesIcon },
+  { id: "transfer", label: "Transfer", Icon: TransferIcon },
+  { id: "bridge", label: "Bridge", Icon: BridgeIcon },
+  { id: "activity", label: "Activity", Icon: ActivityIcon },
+] as const;
+
+export function DashboardProfilePage({
+  address,
+  network,
+  onNetworkChange,
+  profile,
+  snapInstalled,
+  onDisconnect,
+}: Props) {
+  const [walletOpen, setWalletOpen] = useState(false);
+  const [networkOpen, setNetworkOpen] = useState(false);
+  const walletRef = useRef<HTMLDivElement>(null);
+  const networkRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleOutside(e: MouseEvent) {
+      if (walletRef.current && !walletRef.current.contains(e.target as Node)) setWalletOpen(false);
+      if (networkRef.current && !networkRef.current.contains(e.target as Node))
+        setNetworkOpen(false);
+    }
+    document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, []);
+
+  const currentNet = getNetwork(network);
+  const isNonCustodial = profile.keyMode === "external";
+
+  return (
+    <div className={styles.layout}>
+      {/* ── Sidebar ── */}
+      <aside className={styles.sidebar}>
+        <div className={styles.sidebarLogo}>
+          <div className="topbar-logo-icon">
+            <Logo />
+          </div>
+          <span className="topbar-logo-text">Canton dApp</span>
+        </div>
+        <div className={styles.sidebarDivider} />
+        <nav className={styles.sidebarNav}>
+          {NAV.map(({ id, label, Icon }) => (
+            <div key={id} className={cn(styles.navItem, id === "profile" && styles.navItemActive)}>
+              <Icon active={id === "profile"} />
+              <span>{label}</span>
+            </div>
+          ))}
+        </nav>
+      </aside>
+
+      {/* ── Main area ── */}
+      <div className={styles.main}>
+        {/* Top-right pills */}
+        <div className={styles.mainHeader}>
+          <div ref={networkRef} className={styles.pillAnchor}>
+            <button
+              className={`pill ${networkOpen ? "active-amber" : ""}`}
+              onClick={() => {
+                setNetworkOpen((o) => !o);
+                setWalletOpen(false);
+              }}
+            >
+              <span className="pill-dot" style={{ background: currentNet.color }} />
+              <span>{currentNet.name}</span>
+              <Caret open={networkOpen} />
+            </button>
+            {networkOpen && (
+              <NetworkSwitcher
+                current={network}
+                onSelect={(id) => {
+                  onNetworkChange(id as NetworkId);
+                  setNetworkOpen(false);
+                }}
+              />
+            )}
+          </div>
+
+          <div ref={walletRef} className={styles.pillAnchor}>
+            <button
+              className={`pill pill-mono ${walletOpen ? "active-teal" : ""}`}
+              onClick={() => {
+                setWalletOpen((o) => !o);
+                setNetworkOpen(false);
+              }}
+            >
+              <span className="pill-dot" style={{ background: "#34d399" }} />
+              <span>{shortenAddress(address)}</span>
+              <Caret open={walletOpen} />
+            </button>
+            {walletOpen && (
+              <WalletMenu
+                address={address}
+                snapInstalled={snapInstalled}
+                onDisconnect={() => {
+                  setWalletOpen(false);
+                  onDisconnect();
+                }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Page heading */}
+        <h1 className={styles.pageTitle}>Profile</h1>
+        <p className={styles.pageSubtitle}>Your Canton identity and quick actions.</p>
+
+        {/* ── Identity card ── */}
+        <div className={styles.identityCard}>
+          <div>
+            <p className={styles.sectionLabel}>CANTON PARTY</p>
+            <div className={styles.partyIdRow}>
+              <div style={{ minWidth: 0 }}>
+                <p className={styles.partyId}>{profile.cantonPartyId.slice(0, 36)}</p>
+                {profile.cantonPartyId.length > 36 && (
+                  <p className={styles.partyIdCont}>{profile.cantonPartyId.slice(36)}</p>
+                )}
+              </div>
+              <CopyButton text={profile.cantonPartyId} />
+            </div>
+
+            <p className={cn(styles.sectionLabel)} style={{ marginTop: 4 }}>
+              FINGERPRINT
+            </p>
+            <div className={styles.fingerprintRow}>
+              <p className={styles.fingerprint}>{profile.fingerprint}</p>
+              {profile.fingerprint && <CopyButton text={profile.fingerprint} />}
+              <span
+                className={cn(
+                  "mode-tag",
+                  isNonCustodial ? "mode-tag-noncustodial" : "mode-tag-custodial",
+                )}
+              >
+                {isNonCustodial ? "NON-CUSTODIAL" : "CUSTODIAL"}
+              </span>
+            </div>
+          </div>
+
+          {/* Quick actions */}
+          <div className={styles.quickActions}>
+            <p className={styles.sectionLabel}>QUICK ACTIONS</p>
+            <button className={styles.btnSend} disabled>
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path
+                  d="M2 10H18M12 4L18 10L12 16"
+                  stroke="#0a0b14"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <div>
+                <span className={styles.btnActionTitle}>Send tokens</span>
+                <span className={styles.btnActionSub}>Transfer on Canton Network</span>
+              </div>
+            </button>
+            <button className={styles.btnBridge} disabled>
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                <path
+                  d="M2 7H14M11 4L14 7L11 10M18 13H6M9 10L6 13L9 16"
+                  stroke="var(--text-secondary)"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <div>
+                <span className={styles.btnBridgeTitle}>Bridge assets</span>
+                <span className={styles.btnBridgeSub}>Move between networks</span>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        {/* ── Connection card ── */}
+        <div className={styles.connectionCard}>
+          <p className={styles.connectionCardTitle}>Connection</p>
+          <div className={styles.connectionGrid}>
+            <div>
+              <p className={styles.sectionLabel}>METAMASK</p>
+              <div className={styles.connStatus}>
+                <span className={cn(styles.connDot, styles.connDotGreen)} />
+                <span className={styles.connLabel}>Connected</span>
+              </div>
+              <p className={styles.connMeta}>{shortenAddress(address)}</p>
+            </div>
+
+            <div>
+              <p className={styles.sectionLabel}>CANTON SNAP</p>
+              <div className={styles.connStatus}>
+                <span
+                  className={cn(
+                    styles.connDot,
+                    snapInstalled ? styles.connDotGreen : styles.connDotAmber,
+                  )}
+                />
+                <span className={styles.connLabel}>
+                  {snapInstalled ? "Installed · v0.2.0" : "Not installed"}
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <p className={styles.sectionLabel}>MIDDLEWARE</p>
+              <div className={styles.connStatus}>
+                <span className={cn(styles.connDot, styles.connDotAmber)} />
+                <span className={styles.connLabel}>{currentNet.name}</span>
+              </div>
+              <p className={styles.connMeta}>{currentNet.host}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -6,6 +6,7 @@ import { WalletMenu } from "../components/WalletMenu";
 import { shortenAddress } from "../lib/ethereum";
 import { getNetwork, type NetworkId } from "../lib/config";
 import { cn } from "../lib/cn";
+import { checkMiddlewareHealth } from "../lib/middleware";
 import type { UserProfile } from "../lib/middleware";
 import styles from "./DashboardProfilePage.module.css";
 
@@ -15,6 +16,7 @@ interface Props {
   onNetworkChange: (id: NetworkId) => void;
   profile: UserProfile;
   snapInstalled: boolean;
+  snapVersion: string | null;
   onDisconnect: () => void;
 }
 
@@ -32,15 +34,9 @@ function Caret({ open }: { open: boolean }) {
   );
 }
 
-function ProfileIcon({ active }: { active?: boolean }) {
+function ProfileIcon() {
   return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      color={active ? "var(--teal)" : "currentColor"}
-    >
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
       <circle cx="10" cy="7" r="3.5" stroke="currentColor" strokeWidth="1.6" />
       <path
         d="M3 17C3 13 6 11 10 11C14 11 17 13 17 17"
@@ -120,10 +116,12 @@ export function DashboardProfilePage({
   onNetworkChange,
   profile,
   snapInstalled,
+  snapVersion,
   onDisconnect,
 }: Props) {
   const [walletOpen, setWalletOpen] = useState(false);
   const [networkOpen, setNetworkOpen] = useState(false);
+  const [middlewareHealthy, setMiddlewareHealthy] = useState<boolean | null>(null);
   const walletRef = useRef<HTMLDivElement>(null);
   const networkRef = useRef<HTMLDivElement>(null);
 
@@ -133,12 +131,27 @@ export function DashboardProfilePage({
       if (networkRef.current && !networkRef.current.contains(e.target as Node))
         setNetworkOpen(false);
     }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setWalletOpen(false);
+        setNetworkOpen(false);
+      }
+    }
     document.addEventListener("mousedown", handleOutside);
-    return () => document.removeEventListener("mousedown", handleOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
   }, []);
 
   const currentNet = getNetwork(network);
   const isNonCustodial = profile.keyMode === "external";
+
+  useEffect(() => {
+    setMiddlewareHealthy(null);
+    checkMiddlewareHealth(currentNet.middlewareUrl).then(setMiddlewareHealthy);
+  }, [currentNet.middlewareUrl]);
 
   return (
     <div className={styles.layout}>
@@ -153,10 +166,15 @@ export function DashboardProfilePage({
         <div className={styles.sidebarDivider} />
         <nav className={styles.sidebarNav}>
           {NAV.map(({ id, label, Icon }) => (
-            <div key={id} className={cn(styles.navItem, id === "profile" && styles.navItemActive)}>
-              <Icon active={id === "profile"} />
+            <button
+              key={id}
+              className={cn(styles.navItem, id === "profile" && styles.navItemActive)}
+              disabled={id !== "profile"}
+              aria-current={id === "profile" ? "page" : undefined}
+            >
+              <Icon />
               <span>{label}</span>
-            </div>
+            </button>
           ))}
         </nav>
       </aside>
@@ -223,15 +241,23 @@ export function DashboardProfilePage({
             <p className={styles.sectionLabel}>CANTON PARTY</p>
             <div className={styles.partyIdRow}>
               <div style={{ minWidth: 0 }}>
-                <p className={styles.partyId}>{profile.cantonPartyId.slice(0, 36)}</p>
-                {profile.cantonPartyId.length > 36 && (
-                  <p className={styles.partyIdCont}>{profile.cantonPartyId.slice(36)}</p>
-                )}
+                {(() => {
+                  const sep = profile.cantonPartyId.indexOf("::");
+                  const head =
+                    sep >= 0 ? profile.cantonPartyId.slice(0, sep) : profile.cantonPartyId;
+                  const cont = sep >= 0 ? profile.cantonPartyId.slice(sep) : "";
+                  return (
+                    <>
+                      <p className={styles.partyId}>{head}</p>
+                      {cont && <p className={styles.partyIdCont}>{cont}</p>}
+                    </>
+                  );
+                })()}
               </div>
               <CopyButton text={profile.cantonPartyId} />
             </div>
 
-            <p className={cn(styles.sectionLabel)} style={{ marginTop: 4 }}>
+            <p className={styles.sectionLabel} style={{ marginTop: 4 }}>
               FINGERPRINT
             </p>
             <div className={styles.fingerprintRow}>
@@ -307,7 +333,9 @@ export function DashboardProfilePage({
                   )}
                 />
                 <span className={styles.connLabel}>
-                  {snapInstalled ? "Installed · v0.2.0" : "Not installed"}
+                  {snapInstalled
+                    ? `Installed${snapVersion ? ` · v${snapVersion}` : ""}`
+                    : "Not installed"}
                 </span>
               </div>
             </div>
@@ -315,8 +343,21 @@ export function DashboardProfilePage({
             <div>
               <p className={styles.sectionLabel}>MIDDLEWARE</p>
               <div className={styles.connStatus}>
-                <span className={cn(styles.connDot, styles.connDotAmber)} />
-                <span className={styles.connLabel}>{currentNet.name}</span>
+                {middlewareHealthy !== null && (
+                  <span
+                    className={cn(
+                      styles.connDot,
+                      middlewareHealthy ? styles.connDotGreen : styles.connDotAmber,
+                    )}
+                  />
+                )}
+                <span className={styles.connLabel}>
+                  {middlewareHealthy === null
+                    ? currentNet.name
+                    : middlewareHealthy
+                      ? `${currentNet.name} · Connected`
+                      : `${currentNet.name} · Unreachable`}
+                </span>
               </div>
               <p className={styles.connMeta}>{currentNet.host}</p>
             </div>

--- a/packages/dapp/src/pages/LandingPage.tsx
+++ b/packages/dapp/src/pages/LandingPage.tsx
@@ -60,7 +60,7 @@ export function LandingPage({ connecting, error, detected, onConnect }: Props) {
         <span>Your EVM wallet, on Canton Network.</span>
         <div className={styles.footerLinks}>
           <a
-            href="https://github.com/chain-safe/canton-snap"
+            href="https://github.com/chainsafe/canton-snap"
             target="_blank"
             rel="noreferrer"
             className={styles.footerLink}

--- a/packages/dapp/src/pages/RegistrationDonePage.tsx
+++ b/packages/dapp/src/pages/RegistrationDonePage.tsx
@@ -12,7 +12,6 @@ interface Props {
   onNetworkChange: (id: NetworkId) => void;
   cantonPartyId: string;
   fingerprint: string;
-  snapInstalled?: boolean;
   wasAlreadyRegistered?: boolean;
   onDashboard: () => void;
   onDisconnect: () => void;
@@ -24,7 +23,6 @@ export function RegistrationDonePage({
   onNetworkChange,
   cantonPartyId,
   fingerprint,
-  snapInstalled,
   wasAlreadyRegistered,
   onDashboard,
   onDisconnect,
@@ -34,7 +32,6 @@ export function RegistrationDonePage({
       <AmbientOrb opacity={0.22} size={920} y="58%" />
       <TopBar
         address={address}
-        snapInstalled={snapInstalled}
         network={network}
         onNetworkChange={onNetworkChange}
         onDisconnect={onDisconnect}


### PR DESCRIPTION
## Summary

Implements the user profile dashboard and hardens the authentication flow between the dApp and middleware.

### Dashboard profile page (`DashboardProfilePage`)

- Sidebar layout with navigation items (Profile active; Balances, Transfer, Bridge, Activity as disabled placeholders for future pages)
- **Identity card**: displays Canton Party ID split at the `::` separator, fingerprint, custodial/non-custodial badge, and copy buttons for both values. Quick action buttons (Send, Bridge) are present but disabled until those pages are built
- **Connection card**: live status for MetaMask, Canton Snap (version from `wallet_getSnaps`), and Middleware (health-checked on mount and on network switch using a URL-keyed cache to avoid stale state)
- Non-custodial users who later remove the snap see a **Re-install snap** button in the Connection card


### Middleware: server-side message expiry (`canton-middleware`)

- `GET /user` handler reads credentials from `X-Signature`/`X-Message` headers
- `GetUser` validates the login message timestamp with a 24-hour max age via `auth.ValidateTimedMessage` — signatures older than 24 hours are rejected with a 401 `{"error": "...expired..."}` response, triggering a re-sign on the client

### WalletMenu cleanup

- Removed the Canton Snap section from the wallet dropdown (version is shown on the dashboard profile only)
- Replaced the broken two-line address display with a single shortened address + copy button

## Test plan

- [x] New user: connect wallet → sign message → registration choice page appears
- [x] Existing user: connect wallet → dashboard loads directly (no registration)
- [x] Refresh page: spinner shown briefly, then dashboard reloads without re-signing
- [x] Expired session (>24h old message): server returns 401 expired → client clears session and prompts re-sign
- [x] Disconnect → landing page, session cleared; reconnect prompts sign again
- [x] Network switch on dashboard: profile reloads for new network; unregistered address redirects to registration
- [x] Non-custodial user removes snap → dashboard shows amber dot + Re-install button → clicking it reinstalls
- [x] Custodial user: Re-install button does not appear regardless of snap state
- [x] Wallet dropdown: address shown as shortened single line with working copy button; no snap section
