### PR TITLE
feat: custodial and non-custodial token transfer

### DIFF
--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "ethers": "^6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -13,6 +13,7 @@ import { NonCustodialRegistrationPage } from "./pages/NonCustodialRegistrationPa
 import { RegistrationDonePage } from "./pages/RegistrationDonePage";
 import { DashboardProfilePage } from "./pages/DashboardProfilePage";
 import { DashboardBalancesPage } from "./pages/DashboardBalancesPage";
+import { TransferPage } from "./pages/TransferPage";
 import type { DashboardTab } from "./components/DashboardLayout";
 
 type Page =
@@ -315,6 +316,10 @@ export default function App() {
 
     if (dashboardTab === "balances") {
       return <DashboardBalancesPage {...sharedProps} />;
+    }
+
+    if (dashboardTab === "transfer") {
+      return <TransferPage {...sharedProps} keyMode={profile.keyMode} />;
     }
 
     return (

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -13,6 +13,7 @@ import { NonCustodialRegistrationPage } from "./pages/NonCustodialRegistrationPa
 import { RegistrationDonePage } from "./pages/RegistrationDonePage";
 import { DashboardProfilePage } from "./pages/DashboardProfilePage";
 import { DashboardBalancesPage } from "./pages/DashboardBalancesPage";
+import { DashboardActivityPage } from "./pages/DashboardActivityPage";
 import { TransferPage } from "./pages/TransferPage";
 import type { DashboardTab } from "./components/DashboardLayout";
 
@@ -320,6 +321,10 @@ export default function App() {
 
     if (dashboardTab === "transfer") {
       return <TransferPage {...sharedProps} keyMode={profile.keyMode} />;
+    }
+
+    if (dashboardTab === "activity") {
+      return <DashboardActivityPage {...sharedProps} />;
     }
 
     return (

--- a/packages/dapp/src/components/DashboardLayout.module.css
+++ b/packages/dapp/src/components/DashboardLayout.module.css
@@ -83,7 +83,7 @@
 .main {
   flex: 1;
   overflow-y: auto;
-  padding: 40px 48px;
+  padding: 24px 48px 48px;
   min-width: 0;
 }
 
@@ -92,7 +92,7 @@
   justify-content: flex-end;
   align-items: center;
   gap: 12px;
-  margin-bottom: 48px;
+  margin-bottom: 28px;
 }
 
 .pillAnchor {

--- a/packages/dapp/src/components/DashboardLayout.tsx
+++ b/packages/dapp/src/components/DashboardLayout.tsx
@@ -7,7 +7,7 @@ import { getNetwork, type NetworkId } from "../lib/config";
 import { cn } from "../lib/cn";
 import styles from "./DashboardLayout.module.css";
 
-export type DashboardTab = "profile" | "balances";
+export type DashboardTab = "profile" | "balances" | "transfer";
 
 interface Props {
   address: string;
@@ -104,7 +104,7 @@ function ActivityIcon() {
 const NAV = [
   { id: "profile" as DashboardTab, label: "Profile", Icon: ProfileIcon },
   { id: "balances" as DashboardTab, label: "Balances", Icon: BalancesIcon },
-  { id: "transfer", label: "Transfer", Icon: TransferIcon, disabled: true },
+  { id: "transfer" as DashboardTab, label: "Transfer", Icon: TransferIcon },
   { id: "bridge", label: "Bridge", Icon: BridgeIcon, disabled: true },
   { id: "activity", label: "Activity", Icon: ActivityIcon, disabled: true },
 ];
@@ -167,7 +167,7 @@ export function DashboardLayout({
                 disabled={isDisabled}
                 aria-current={isActive ? "page" : undefined}
                 onClick={() => {
-                  if (id === "profile" || id === "balances") onTabChange(id);
+                  if (id === "profile" || id === "balances" || id === "transfer") onTabChange(id);
                 }}
               >
                 <Icon />

--- a/packages/dapp/src/components/DashboardLayout.tsx
+++ b/packages/dapp/src/components/DashboardLayout.tsx
@@ -7,7 +7,7 @@ import { getNetwork, type NetworkId } from "../lib/config";
 import { cn } from "../lib/cn";
 import styles from "./DashboardLayout.module.css";
 
-export type DashboardTab = "profile" | "balances" | "transfer";
+export type DashboardTab = "profile" | "balances" | "transfer" | "activity";
 
 interface Props {
   address: string;
@@ -106,7 +106,7 @@ const NAV = [
   { id: "balances" as DashboardTab, label: "Balances", Icon: BalancesIcon },
   { id: "transfer" as DashboardTab, label: "Transfer", Icon: TransferIcon },
   { id: "bridge", label: "Bridge", Icon: BridgeIcon, disabled: true },
-  { id: "activity", label: "Activity", Icon: ActivityIcon, disabled: true },
+  { id: "activity" as DashboardTab, label: "Activity", Icon: ActivityIcon },
 ];
 
 export function DashboardLayout({
@@ -167,7 +167,13 @@ export function DashboardLayout({
                 disabled={isDisabled}
                 aria-current={isActive ? "page" : undefined}
                 onClick={() => {
-                  if (id === "profile" || id === "balances" || id === "transfer") onTabChange(id);
+                  if (
+                    id === "profile" ||
+                    id === "balances" ||
+                    id === "transfer" ||
+                    id === "activity"
+                  )
+                    onTabChange(id);
                 }}
               >
                 <Icon />

--- a/packages/dapp/src/components/PageCard.module.css
+++ b/packages/dapp/src/components/PageCard.module.css
@@ -1,0 +1,8 @@
+.card {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  max-width: 768px;
+  margin-left: max(0px, calc(50% - 432px));
+  margin-right: auto;
+}

--- a/packages/dapp/src/components/PageCard.tsx
+++ b/packages/dapp/src/components/PageCard.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { cn } from "../lib/cn";
+import styles from "./PageCard.module.css";
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+
+export function PageCard({ children, className }: Props) {
+  return <div className={cn(styles.card, className)}>{children}</div>;
+}

--- a/packages/dapp/src/hooks/useSnap.ts
+++ b/packages/dapp/src/hooks/useSnap.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { sha256, getBytes } from "ethers";
 import { installSnap, getInstalledSnap, invokeSnap } from "../lib/ethereum";
 
 export interface SnapPublicKey {
@@ -79,7 +80,10 @@ export function useSnap(): SnapState {
 
   const signHash = useCallback(
     async (hash: string, metadata?: SignHashMetadata): Promise<SignHashResult> => {
-      return invokeSnap<SignHashResult>("canton_signHash", { hash, metadata });
+      // Canton returns a multihash from PrepareSubmission. Match Go's keys.SignDER:
+      // sha256 the raw multihash bytes so the snap signs the correct 32-byte digest.
+      const digest = sha256(getBytes(hash));
+      return invokeSnap<SignHashResult>("canton_signHash", { hash: digest, metadata });
     },
     [],
   );

--- a/packages/dapp/src/hooks/useSnap.ts
+++ b/packages/dapp/src/hooks/useSnap.ts
@@ -7,6 +7,19 @@ export interface SnapPublicKey {
   spkiDer: string;
 }
 
+export interface SignHashMetadata {
+  operation: string;
+  tokenSymbol: string;
+  amount: string;
+  recipient?: string;
+  sender?: string;
+}
+
+export interface SignHashResult {
+  derSignature: string;
+  fingerprint: string;
+}
+
 export interface SnapState {
   installed: boolean;
   alreadyInstalled: boolean;
@@ -16,6 +29,7 @@ export interface SnapState {
   install: () => Promise<boolean>;
   getPublicKey: (keyIndex?: number) => Promise<SnapPublicKey>;
   signTopology: (hash: string) => Promise<string>;
+  signHash: (hash: string, metadata?: SignHashMetadata) => Promise<SignHashResult>;
 }
 
 export function useSnap(): SnapState {
@@ -63,6 +77,13 @@ export function useSnap(): SnapState {
     return result.derSignature;
   }, []);
 
+  const signHash = useCallback(
+    async (hash: string, metadata?: SignHashMetadata): Promise<SignHashResult> => {
+      return invokeSnap<SignHashResult>("canton_signHash", { hash, metadata });
+    },
+    [],
+  );
+
   return {
     installed,
     alreadyInstalled,
@@ -72,5 +93,6 @@ export function useSnap(): SnapState {
     install,
     getPublicKey,
     signTopology,
+    signHash,
   };
 }

--- a/packages/dapp/src/lib/ethereum.ts
+++ b/packages/dapp/src/lib/ethereum.ts
@@ -1,3 +1,5 @@
+import { getAddress } from "ethers";
+
 export const SNAP_ID = `local:http://localhost:${import.meta.env.VITE_SNAP_PORT ?? 8080}`;
 
 declare global {
@@ -85,4 +87,12 @@ export async function sendEthTransaction(params: {
 
 export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars + 2)}…${address.slice(-chars)}`;
+}
+
+export function toChecksumAddress(address: string): string {
+  try {
+    return getAddress(address);
+  } catch {
+    return address;
+  }
 }

--- a/packages/dapp/src/lib/ethereum.ts
+++ b/packages/dapp/src/lib/ethereum.ts
@@ -63,6 +63,26 @@ export async function invokeSnap<T>(method: string, params: unknown): Promise<T>
   }) as Promise<T>;
 }
 
+export async function addEthChain(params: {
+  chainId: string;
+  chainName: string;
+  rpcUrls: string[];
+  nativeCurrency: { name: string; symbol: string; decimals: number };
+}): Promise<void> {
+  await getEthereum().request({ method: "wallet_addEthereumChain", params: [params] });
+}
+
+export async function sendEthTransaction(params: {
+  from: string;
+  to: string;
+  data: string;
+}): Promise<string> {
+  return getEthereum().request({
+    method: "eth_sendTransaction",
+    params: [{ ...params, value: "0x0" }],
+  }) as Promise<string>;
+}
+
 export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars + 2)}…${address.slice(-chars)}`;
 }

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -30,6 +30,29 @@ export async function getTokenBalance(
   return BigInt(result);
 }
 
+export function encodeTransfer(to: string, amount: bigint): string {
+  const toEncoded = to.replace(/^0x/i, "").toLowerCase().padStart(64, "0");
+  const amountEncoded = amount.toString(16).padStart(64, "0");
+  return "0xa9059cbb" + toEncoded + amountEncoded;
+}
+
+export function parseTokenAmount(value: string, decimals: number): bigint {
+  const [whole, frac = ""] = value.trim().split(".");
+  const fracPadded = frac.slice(0, decimals).padEnd(decimals, "0");
+  return BigInt(whole || "0") * 10n ** BigInt(decimals) + BigInt(fracPadded || "0");
+}
+
+export async function ethChainId(rpcUrl: string): Promise<string> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", params: [], id: ++_rpcId }),
+  });
+  const json = await res.json();
+  if (json.error) throw new Error(json.error.message as string);
+  return json.result as string;
+}
+
 export function formatTokenAmount(raw: bigint, decimals: number): string {
   if (raw === 0n) return "0";
   const divisor = 10n ** BigInt(decimals);

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -37,8 +37,12 @@ export function encodeTransfer(to: string, amount: bigint): string {
 }
 
 export function parseTokenAmount(value: string, decimals: number): bigint {
-  const [whole, frac = ""] = value.trim().split(".");
-  const fracPadded = frac.slice(0, decimals).padEnd(decimals, "0");
+  const parts = value.trim().split(".");
+  if (parts.length > 2) throw new Error("Invalid amount format");
+  const whole = (parts[0] ?? "").replace(/,/g, "");
+  const frac = parts[1] ?? "";
+  if (frac.length > decimals) throw new Error("Too many decimal places");
+  const fracPadded = frac.padEnd(decimals, "0");
   return BigInt(whole || "0") * 10n ** BigInt(decimals) + BigInt(fracPadded || "0");
 }
 

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -1,5 +1,11 @@
 let _rpcId = 0;
 
+const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+function padAddress(address: string): string {
+  return "0x000000000000000000000000" + address.replace(/^0x/i, "").toLowerCase();
+}
+
 function encodeBalanceOf(address: string): string {
   return "0x70a08231" + address.replace(/^0x/i, "").toLowerCase().padStart(64, "0");
 }
@@ -55,6 +61,113 @@ export async function ethChainId(rpcUrl: string): Promise<string> {
   const json = await res.json();
   if (json.error) throw new Error(json.error.message as string);
   return json.result as string;
+}
+
+interface RawLog {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  blockTimestamp: string; // added by canton-middleware PR #241
+  transactionHash: string;
+  logIndex: string;
+}
+
+export interface TransferLog {
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+  timestamp: number;
+  direction: "sent" | "received";
+  tokenAddress: string;
+  amount: bigint;
+  from: string;
+  to: string;
+}
+
+async function ethGetLogs(rpcUrl: string, filter: unknown): Promise<RawLog[]> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_getLogs",
+      params: [filter],
+      id: ++_rpcId,
+    }),
+  });
+  const json = (await res.json()) as { result?: unknown; error?: { message: string } };
+  if (json.error) throw new Error(json.error.message);
+  return (json.result as RawLog[]) ?? [];
+}
+
+async function ethBlockNumber(rpcUrl: string): Promise<string> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_blockNumber",
+      params: [],
+      id: ++_rpcId,
+    }),
+  });
+  const json = (await res.json()) as { result?: string; error?: { message: string } };
+  if (json.error) throw new Error(json.error.message);
+  return json.result ?? "0x0";
+}
+
+export async function getTransferLogs(
+  rpcUrl: string,
+  tokenAddresses: string[],
+  userAddress: string,
+): Promise<TransferLog[]> {
+  if (tokenAddresses.length === 0) return [];
+
+  const paddedUser = padAddress(userAddress);
+  // TODO: replace fromBlock "0x0" with block-range pagination once chain history grows
+  const toBlock = await ethBlockNumber(rpcUrl);
+
+  const [sentRaw, receivedRaw] = await Promise.all([
+    ethGetLogs(rpcUrl, {
+      fromBlock: "0x0",
+      toBlock,
+      address: tokenAddresses,
+      topics: [ERC20_TRANSFER_TOPIC, paddedUser],
+    }),
+    ethGetLogs(rpcUrl, {
+      fromBlock: "0x0",
+      toBlock,
+      address: tokenAddresses,
+      topics: [ERC20_TRANSFER_TOPIC, null, paddedUser],
+    }),
+  ]);
+
+  // self-transfers appear in both queries — keep them under "sent" only
+  const sentKeys = new Set(sentRaw.map((l) => `${l.transactionHash}-${l.logIndex}`));
+  const uniqueReceived = receivedRaw.filter(
+    (l) => !sentKeys.has(`${l.transactionHash}-${l.logIndex}`),
+  );
+
+  const allLogs = [
+    ...sentRaw.map((l) => ({ ...l, direction: "sent" as const })),
+    ...uniqueReceived.map((l) => ({ ...l, direction: "received" as const })),
+  ];
+
+  return allLogs
+    .filter((l) => l.topics.length >= 3)
+    .map((l) => ({
+      txHash: l.transactionHash,
+      blockNumber: parseInt(l.blockNumber, 16),
+      logIndex: parseInt(l.logIndex, 16),
+      timestamp: l.blockTimestamp ? parseInt(l.blockTimestamp, 16) : 0,
+      direction: l.direction,
+      tokenAddress: l.address.toLowerCase(),
+      amount: l.data && l.data !== "0x" ? BigInt(l.data) : 0n,
+      from: "0x" + l.topics[1].slice(26),
+      to: "0x" + l.topics[2].slice(26),
+    }))
+    .sort((a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex);
 }
 
 export function formatTokenAmount(raw: bigint, decimals: number): string {

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -42,7 +42,8 @@ export async function getTokens(baseUrl: string): Promise<TokenConfig[]> {
     all.push(...data.items.filter(isTokenConfig));
 
     if (!data.has_more) break;
-    if (!data.next_cursor) throw new Error("Unexpected tokens response: has_more is true but next_cursor is missing");
+    if (!data.next_cursor)
+      throw new Error("Unexpected tokens response: has_more is true but next_cursor is missing");
     cursor = data.next_cursor;
   }
 

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -107,7 +107,7 @@ async function post<T>(baseUrl: string, path: string, body: unknown): Promise<T>
   return JSON.parse(text);
 }
 
-function friendlyError(status: number, body: string): string {
+export function friendlyError(status: number, body: string): string {
   if (status === 403) {
     try {
       const parsed = JSON.parse(body);

--- a/packages/dapp/src/lib/transfer.ts
+++ b/packages/dapp/src/lib/transfer.ts
@@ -1,0 +1,54 @@
+import { personalSign } from "./ethereum";
+import { friendlyError } from "./middleware";
+
+export interface PrepareResult {
+  transferId: string;
+  transactionHash: string;
+  partyId: string;
+  expiresAt: string;
+}
+
+async function makeAuthHeaders(address: string): Promise<Record<string, string>> {
+  const message = `transfer:${Math.floor(Date.now() / 1000)}`;
+  const signature = await personalSign(message, address);
+  return { "X-Signature": signature, "X-Message": message };
+}
+
+export async function prepareTransfer(
+  baseUrl: string,
+  address: string,
+  to: string,
+  token: string,
+  amount: string,
+): Promise<PrepareResult> {
+  const authHeaders = await makeAuthHeaders(address);
+  const res = await fetch(`${baseUrl}/api/v2/transfer/prepare`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders },
+    body: JSON.stringify({ to, amount, token }),
+  });
+  if (!res.ok) throw new Error(friendlyError(res.status, await res.text()));
+  const data = await res.json();
+  return {
+    transferId: data.transfer_id as string,
+    transactionHash: data.transaction_hash as string,
+    partyId: data.party_id as string,
+    expiresAt: data.expires_at as string,
+  };
+}
+
+export async function executeTransfer(
+  baseUrl: string,
+  address: string,
+  transferId: string,
+  signature: string,
+  signedBy: string,
+): Promise<void> {
+  const authHeaders = await makeAuthHeaders(address);
+  const res = await fetch(`${baseUrl}/api/v2/transfer/execute`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders },
+    body: JSON.stringify({ transfer_id: transferId, signature, signed_by: signedBy }),
+  });
+  if (!res.ok) throw new Error(friendlyError(res.status, await res.text()));
+}

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -1,0 +1,337 @@
+/* ── Page header ── */
+.pageHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.pageTitles {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pageTitle {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+  color: var(--text-primary);
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* ── Search ── */
+.searchBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 296px;
+  height: 36px;
+  background: #12141f;
+  border: 1px solid var(--border-muted);
+  border-radius: 10px;
+  padding: 0 14px;
+  color: var(--text-muted);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.searchInput {
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: var(--font-sans);
+  width: 100%;
+}
+
+.searchInput::placeholder {
+  color: var(--text-muted);
+}
+
+.searchBarDisabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.searchBarDisabled .searchInput {
+  cursor: not-allowed;
+}
+
+/* ── Filter tabs ── */
+.filters {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.filterTabs {
+  display: flex;
+  gap: 8px;
+}
+
+.filterTab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #12141f;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.filterTab:hover:not(.filterTabActive) {
+  background: #1a1d2e;
+  color: var(--text-primary);
+}
+
+.filterTabActive {
+  background: #1a1d2e;
+  border-color: var(--border-muted);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.filterTabCount {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 5px;
+  background: #232640;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* ── Column headers (above card) ── */
+.colHeaders {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  column-gap: 32px;
+  padding: 0 24px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.colRight {
+  text-align: right;
+}
+
+/* ── Activity card (full-width) ── */
+.card {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+/* ── Day group label ── */
+.dayGroup {
+  padding: 16px 24px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+/* ── Activity row ── */
+.rowDivider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 24px;
+}
+
+.activityRow {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  column-gap: 32px;
+  align-items: center;
+  padding: 16px 24px;
+}
+
+/* Type cell */
+.typeCell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.typeIcon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.iconSent {
+  background: rgba(0, 212, 164, 0.12);
+  color: #00d4a4;
+}
+
+.iconReceived {
+  background: rgba(96, 165, 250, 0.14);
+  color: #60a5fa;
+}
+
+.typeLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* Token cell */
+.tokenCell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tokenIcon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.tokenSymbol {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* Address / tx cells */
+.addrCell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.addrLabel {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.addrRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.addrValue {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+
+/* Amount cell */
+.amountCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+}
+
+.amountValue {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.amountSent {
+  color: var(--text-primary);
+}
+
+.amountReceived {
+  color: #34d399;
+}
+
+.amountLabel {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* When cell */
+.whenCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+
+.whenRelative {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.whenAbsolute {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Loading / error / empty */
+.centred {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.errorText {
+  font-size: 13px;
+  color: var(--amber);
+  text-align: center;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* ── Footer ── */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-top: 1px solid var(--border);
+}
+
+.footerCount {
+  font-size: 12px;
+  color: var(--text-muted);
+}

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -1,0 +1,380 @@
+import { useState, useEffect, useMemo } from "react";
+import { AmbientOrb } from "../components/AmbientOrb";
+import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
+import { Spinner } from "../components/Spinner";
+import { getNetwork, type NetworkId } from "../lib/config";
+import { getTokens, type TokenConfig } from "../lib/middleware";
+import { getTransferLogs, formatTokenAmount, type TransferLog } from "../lib/ethrpc";
+import { TOKEN_COLORS } from "../lib/tokens";
+import { toChecksumAddress, shortenAddress } from "../lib/ethereum";
+import { CopyButton } from "../components/CopyButton";
+import styles from "./DashboardActivityPage.module.css";
+
+interface Props {
+  address: string;
+  network: NetworkId;
+  onNetworkChange: (id: NetworkId) => void;
+  activeTab: DashboardTab;
+  onTabChange: (tab: DashboardTab) => void;
+  onDisconnect: () => void;
+}
+
+interface ActivityRow extends TransferLog {
+  token: TokenConfig;
+}
+
+type FilterTab = "transfers" | "bridge";
+
+type FetchState =
+  | { url: string; address: string; rows: ActivityRow[]; error: null }
+  | { url: string; address: string; rows: null; error: string };
+
+// Jan 1 2020 in Unix seconds — anything before this is a synthetic/bogus timestamp
+const MIN_REAL_TIMESTAMP = 1577836800;
+
+function relativeTime(ts: number): string {
+  if (!ts || ts < MIN_REAL_TIMESTAMP) return "—";
+  const diff = Date.now() / 1000 - ts;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 172800) return "Yesterday";
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function timeUTC(ts: number): string {
+  if (!ts || ts < MIN_REAL_TIMESTAMP) return "";
+  return new Date(ts * 1000).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+}
+
+function dayKey(ts: number): string {
+  if (!ts) return "unknown";
+  return new Date(ts * 1000).toDateString();
+}
+
+function dayLabel(ts: number): string {
+  if (!ts) return "UNKNOWN";
+  const d = new Date(ts * 1000);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const month = d.toLocaleDateString("en-US", { month: "short", day: "numeric" }).toUpperCase();
+  if (d.toDateString() === today.toDateString()) return `TODAY · ${month}`;
+  if (d.toDateString() === yesterday.toDateString()) return `YESTERDAY · ${month}`;
+  return d
+    .toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
+    .toUpperCase();
+}
+
+function ArrowUpIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M10 15V5M5 10L10 5L15 10"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M10 5V15M5 10L10 15L15 10"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function TokenIcon({ symbol }: { symbol: string }) {
+  const colors = TOKEN_COLORS[symbol.toUpperCase()] ?? { bg: "#656a8a", text: "#ffffff" };
+  return (
+    <div className={styles.tokenIcon} style={{ background: colors.bg, color: colors.text }}>
+      {symbol.charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9.5 9.5L12 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function DashboardActivityPage({
+  address,
+  network,
+  onNetworkChange,
+  activeTab,
+  onTabChange,
+  onDisconnect,
+}: Props) {
+  const [fetchState, setFetchState] = useState<FetchState | null>(null);
+  const [filterTab, setFilterTab] = useState<FilterTab>("transfers");
+  const [search, setSearch] = useState("");
+
+  const currentNet = getNetwork(network);
+  const loading = fetchState?.url !== currentNet.middlewareUrl || fetchState?.address !== address;
+
+  useEffect(() => {
+    let cancelled = false;
+    const rpcUrl = `${currentNet.middlewareUrl}/eth`;
+
+    async function load() {
+      try {
+        const tokens = await getTokens(currentNet.middlewareUrl);
+        const tokenByAddress = new Map(tokens.map((t) => [t.address.toLowerCase(), t]));
+        const logs = await getTransferLogs(
+          rpcUrl,
+          tokens.map((t) => t.address),
+          address,
+        );
+        const rows: ActivityRow[] = logs
+          .map((log) => {
+            const token = tokenByAddress.get(log.tokenAddress);
+            if (!token) return null;
+            return { ...log, token };
+          })
+          .filter((r): r is ActivityRow => r !== null);
+
+        if (!cancelled)
+          setFetchState({ url: currentNet.middlewareUrl, address, rows, error: null });
+      } catch (e: unknown) {
+        if (!cancelled)
+          setFetchState({
+            url: currentNet.middlewareUrl,
+            address,
+            rows: null,
+            error: (e as Error).message,
+          });
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentNet.middlewareUrl, address]);
+
+  const filtered = useMemo(() => {
+    const rows = fetchState?.rows ?? [];
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter(
+      (r) =>
+        r.txHash.toLowerCase().includes(q) ||
+        r.from.toLowerCase().includes(q) ||
+        r.to.toLowerCase().includes(q) ||
+        r.token.symbol.toLowerCase().includes(q),
+    );
+  }, [fetchState, search]);
+
+  // Group rows by calendar day
+  const groups = useMemo(() => {
+    const map = new Map<string, ActivityRow[]>();
+    for (const row of filtered) {
+      const key = dayKey(row.timestamp);
+      const arr = map.get(key) ?? [];
+      arr.push(row);
+      map.set(key, arr);
+    }
+    return [...map.entries()].map(([key, rows]) => ({ key, rows }));
+  }, [filtered]);
+
+  return (
+    <>
+      <AmbientOrb opacity={0.1} size={880} x="80%" y="33%" />
+      <DashboardLayout
+        address={address}
+        network={network}
+        onNetworkChange={onNetworkChange}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        onDisconnect={onDisconnect}
+      >
+        {/* Header */}
+        <div className={styles.pageHeader}>
+          <div className={styles.pageTitles}>
+            <h1 className={styles.pageTitle}>Activity</h1>
+            <p className={styles.pageSubtitle}>
+              Token transfers and bridge events for this wallet.
+            </p>
+          </div>
+          <label
+            className={`${styles.searchBar} ${filterTab === "bridge" ? styles.searchBarDisabled : ""}`}
+          >
+            <SearchIcon />
+            <input
+              className={styles.searchInput}
+              placeholder="Search by tx hash, address, or token…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              disabled={filterTab === "bridge"}
+            />
+          </label>
+        </div>
+
+        {/* Filter tabs */}
+        <div className={styles.filters}>
+          <div className={styles.filterTabs}>
+            {(["transfers", "bridge"] as FilterTab[]).map((tab) => (
+              <button
+                key={tab}
+                className={`${styles.filterTab} ${filterTab === tab ? styles.filterTabActive : ""}`}
+                onClick={() => setFilterTab(tab)}
+              >
+                {tab === "transfers" ? "Transfers" : "Bridge"}
+                {!loading && fetchState?.rows && tab === "transfers" && (
+                  <span className={styles.filterTabCount}>{filtered.length}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Column headers */}
+        <div className={styles.colHeaders}>
+          <span>TYPE</span>
+          <span>TOKEN</span>
+          <span>AMOUNT</span>
+          <span>TO / FROM</span>
+          <span>TX HASH</span>
+          <span className={styles.colRight}>DATE</span>
+        </div>
+
+        {/* Card */}
+        <div className={styles.card}>
+          {loading && (
+            <div className={styles.centred}>
+              <Spinner />
+            </div>
+          )}
+
+          {!loading && filterTab === "transfers" && fetchState?.error && (
+            <div className={styles.centred}>
+              <p className={styles.errorText}>{fetchState.error}</p>
+            </div>
+          )}
+
+          {!loading && filterTab === "bridge" && (
+            <div className={styles.centred}>
+              <p className={styles.hint}>Bridge activity coming soon.</p>
+            </div>
+          )}
+
+          {!loading && filterTab === "transfers" && fetchState?.rows && filtered.length === 0 && (
+            <div className={styles.centred}>
+              <p className={styles.hint}>
+                {search.trim()
+                  ? "No transfers match your search."
+                  : "No transfers found for this address."}
+              </p>
+            </div>
+          )}
+
+          {!loading &&
+            filterTab === "transfers" &&
+            fetchState?.rows &&
+            filtered.length > 0 &&
+            groups.map(({ key, rows }) => (
+              <div key={key}>
+                <div className={styles.dayGroup}>{dayLabel(rows[0].timestamp)}</div>
+                {rows.map((row, i) => {
+                  const isSent = row.direction === "sent";
+                  const counterparty = toChecksumAddress(isSent ? row.to : row.from);
+                  const shortTx = `${row.txHash.slice(0, 10)}…${row.txHash.slice(-8)}`;
+
+                  return (
+                    <div key={`${row.txHash}-${row.logIndex}`}>
+                      {i > 0 && <div className={styles.rowDivider} />}
+                      <div className={styles.activityRow}>
+                        {/* Type */}
+                        <div className={styles.typeCell}>
+                          <div
+                            className={`${styles.typeIcon} ${isSent ? styles.iconSent : styles.iconReceived}`}
+                          >
+                            {isSent ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                          </div>
+                          <span className={styles.typeLabel}>{isSent ? "Sent" : "Received"}</span>
+                        </div>
+
+                        {/* Token */}
+                        <div className={styles.tokenCell}>
+                          <TokenIcon symbol={row.token.symbol} />
+                          <span className={styles.tokenSymbol}>{row.token.symbol}</span>
+                        </div>
+
+                        {/* Amount */}
+                        <div className={styles.amountCell}>
+                          <span
+                            className={`${styles.amountValue} ${isSent ? styles.amountSent : styles.amountReceived}`}
+                          >
+                            {isSent ? "−" : "+"}
+                            {formatTokenAmount(row.amount, row.token.decimals)}
+                          </span>
+                        </div>
+
+                        {/* To / From */}
+                        <div className={styles.addrCell}>
+                          <span className={styles.addrLabel}>{isSent ? "To" : "From"}</span>
+                          <div className={styles.addrRow}>
+                            <span className={styles.addrValue}>
+                              {shortenAddress(counterparty, 5)}
+                            </span>
+                            <CopyButton text={counterparty} />
+                          </div>
+                        </div>
+
+                        {/* Tx hash */}
+                        <div className={styles.addrCell}>
+                          <span className={styles.addrLabel}>Tx</span>
+                          <div className={styles.addrRow}>
+                            <span className={styles.addrValue}>{shortTx}</span>
+                            <CopyButton text={row.txHash} />
+                          </div>
+                        </div>
+
+                        {/* Date */}
+                        <div className={styles.whenCell}>
+                          <span className={styles.whenRelative}>{relativeTime(row.timestamp)}</span>
+                          <span className={styles.whenAbsolute}>
+                            {row.timestamp >= MIN_REAL_TIMESTAMP
+                              ? timeUTC(row.timestamp)
+                              : `Block #${row.blockNumber}`}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+
+          {!loading && filterTab === "transfers" && fetchState?.rows && filtered.length > 0 && (
+            <div className={styles.footer}>
+              <span className={styles.footerCount}>
+                Showing {filtered.length} transfer{filtered.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+          )}
+        </div>
+      </DashboardLayout>
+    </>
+  );
+}

--- a/packages/dapp/src/pages/DashboardBalancesPage.module.css
+++ b/packages/dapp/src/pages/DashboardBalancesPage.module.css
@@ -145,11 +145,14 @@
   color: var(--teal);
   background: none;
   border: none;
-  cursor: not-allowed;
-  opacity: 0.4;
+  cursor: pointer;
   font-family: var(--font-sans);
   padding: 0;
   white-space: nowrap;
+}
+
+.sendRowBtn:hover {
+  text-decoration: underline;
 }
 
 /* Loading / error */

--- a/packages/dapp/src/pages/DashboardBalancesPage.module.css
+++ b/packages/dapp/src/pages/DashboardBalancesPage.module.css
@@ -39,9 +39,6 @@
 
 /* ── Token card ── */
 .card {
-  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
-  border: 1px solid var(--border);
-  border-radius: 16px;
   padding: 0 24px;
   position: relative;
   z-index: 1;

--- a/packages/dapp/src/pages/DashboardBalancesPage.tsx
+++ b/packages/dapp/src/pages/DashboardBalancesPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
+import { PageCard } from "../components/PageCard";
 import { Spinner } from "../components/Spinner";
 import { getNetwork, type NetworkId } from "../lib/config";
 import { getTokens, type TokenConfig } from "../lib/middleware";
@@ -112,7 +113,7 @@ export function DashboardBalancesPage({
         </div>
 
         {/* Token card */}
-        <div className={styles.card}>
+        <PageCard className={styles.card}>
           {/* Column headers */}
           <div className={styles.colHeaders}>
             <span>TOKEN</span>
@@ -171,7 +172,7 @@ export function DashboardBalancesPage({
               </p>
             </>
           )}
-        </div>
+        </PageCard>
       </DashboardLayout>
     </>
   );

--- a/packages/dapp/src/pages/DashboardBalancesPage.tsx
+++ b/packages/dapp/src/pages/DashboardBalancesPage.tsx
@@ -156,10 +156,7 @@ export function DashboardBalancesPage({
                       <p className={styles.amount}>{formatTokenAmount(balance, token.decimals)}</p>
                       <p className={styles.amountLabel}>{token.symbol}</p>
                     </div>
-                    <button
-                      className={styles.sendRowBtn}
-                      onClick={() => onTabChange("transfer")}
-                    >
+                    <button className={styles.sendRowBtn} onClick={() => onTabChange("transfer")}>
                       Send →
                     </button>
                   </div>

--- a/packages/dapp/src/pages/DashboardBalancesPage.tsx
+++ b/packages/dapp/src/pages/DashboardBalancesPage.tsx
@@ -155,7 +155,10 @@ export function DashboardBalancesPage({
                       <p className={styles.amount}>{formatTokenAmount(balance, token.decimals)}</p>
                       <p className={styles.amountLabel}>{token.symbol}</p>
                     </div>
-                    <button className={styles.sendRowBtn} disabled>
+                    <button
+                      className={styles.sendRowBtn}
+                      onClick={() => onTabChange("transfer")}
+                    >
                       Send →
                     </button>
                   </div>

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  margin-bottom: 32px;
+  margin-bottom: 6px;
 }
 
 .pageTitle {
@@ -13,18 +13,23 @@
   color: var(--text-primary);
 }
 
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 32px;
+}
+
 .modePill {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 1.2px;
-  padding: 4px 10px;
-  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  padding: 4px 12px;
+  border-radius: 12px;
   flex-shrink: 0;
-  align-self: center;
 }
 
 .modePillCustodial {
-  background: rgba(139, 124, 255, 0.15);
+  background: rgba(139, 124, 255, 0.12);
   color: #8b7cff;
   border: 1px solid rgba(139, 124, 255, 0.3);
 }
@@ -32,50 +37,59 @@
 .modePillNonCustodial {
   background: rgba(0, 212, 164, 0.12);
   color: #00d4a4;
-  border: 1px solid rgba(0, 212, 164, 0.25);
+  border: 1px solid rgba(0, 212, 164, 0.3);
 }
 
 /* ── Steps bar ── */
 .stepsBar {
   display: flex;
   align-items: center;
-  gap: 0;
   margin-bottom: 32px;
+}
+
+.stepSegment {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.stepSegment:last-child {
+  flex: 0;
 }
 
 .stepItem {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-shrink: 0;
 }
 
 .stepDot {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
   flex-shrink: 0;
-  transition: background 0.2s, border-color 0.2s;
 }
 
 .stepDotPending {
   background: transparent;
-  border: 2px solid var(--border-muted);
-  color: var(--text-muted);
+  border: 2px solid #353a5a;
+  color: #656a8a;
 }
 
 .stepDotActive {
-  background: var(--teal-gradient);
-  border: 2px solid transparent;
+  background: #00d4a4;
+  border: 2px solid #00d4a4;
   color: #0a0b14;
 }
 
 .stepDotDone {
-  background: rgba(0, 212, 164, 0.15);
+  background: transparent;
   border: 2px solid #00d4a4;
   color: #00d4a4;
 }
@@ -83,12 +97,11 @@
 .stepLabel {
   font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.5px;
   white-space: nowrap;
 }
 
 .stepLabelPending {
-  color: var(--text-muted);
+  color: #656a8a;
 }
 
 .stepLabelActive {
@@ -96,15 +109,23 @@
 }
 
 .stepLabelDone {
-  color: #00d4a4;
+  color: var(--text-secondary);
+  font-weight: 500;
 }
 
 .stepConnector {
   flex: 1;
-  height: 1px;
-  background: var(--border);
+  height: 2px;
   margin: 0 12px;
-  min-width: 32px;
+  min-width: 24px;
+}
+
+.stepConnectorPending {
+  background: #353a5a;
+}
+
+.stepConnectorDone {
+  background: #00d4a4;
 }
 
 /* ── Form card ── */
@@ -113,14 +134,14 @@
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 32px;
-  margin-bottom: 16px;
+  margin-bottom: 0;
 }
 
 .fieldLabel {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 1.2px;
-  color: var(--text-muted);
+  color: #656a8a;
   margin-bottom: 10px;
 }
 
@@ -128,90 +149,198 @@
   margin-bottom: 24px;
 }
 
-.fieldGroup:last-child {
-  margin-bottom: 0;
+/* ── Token dropdown ── */
+.tokenDropdownWrapper {
+  position: relative;
 }
 
-/* Token selector */
-.tokenSelect {
+.tokenDropdownTrigger {
   width: 100%;
-  background: #0a0b14;
-  border: 1px solid var(--border-muted);
+  background: #1a1d2e;
+  border: 1px solid #353a5a;
   border-radius: 10px;
-  padding: 14px 16px;
-  color: var(--text-primary);
-  font-size: 15px;
-  font-weight: 600;
-  font-family: var(--font-sans);
+  padding: 0 16px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
   cursor: pointer;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%23656a8a' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 16px center;
+  text-align: left;
+  font-family: var(--font-sans);
 }
 
-.tokenSelect:focus {
+.tokenDropdownTrigger:focus {
   outline: none;
   border-color: var(--teal);
 }
 
-/* Text inputs */
-.input {
-  width: 100%;
-  background: #0a0b14;
-  border: 1px solid var(--border-muted);
-  border-radius: 10px;
-  padding: 14px 16px;
-  color: var(--text-primary);
-  font-size: 15px;
-  font-family: var(--font-mono);
-  box-sizing: border-box;
+.tokenAvatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  flex-shrink: 0;
 }
 
-.input::placeholder {
-  color: var(--text-muted);
+.tokenDropdownInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.tokenDropdownName {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: block;
+}
+
+.tokenDropdownBalance {
+  font-size: 11px;
+  color: #656a8a;
+  display: block;
+  margin-top: 2px;
+}
+
+.tokenDropdownChevron {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.tokenDropdownMenu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: #1a1d2e;
+  border: 1px solid #353a5a;
+  border-radius: 10px;
+  z-index: 10;
+  overflow: hidden;
+}
+
+.tokenDropdownItem {
+  width: 100%;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+}
+
+.tokenDropdownItem:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.tokenDropdownItemName {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: block;
+}
+
+.tokenDropdownItemBalance {
+  font-size: 11px;
+  color: #656a8a;
+  display: block;
+  margin-top: 1px;
+}
+
+/* ── Recipient input ── */
+.recipientWrapper {
+  background: #1a1d2e;
+  border: 1px solid #353a5a;
+  border-radius: 10px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 56px;
+}
+
+.recipientWrapper:focus-within {
+  border-color: var(--teal);
+}
+
+.recipientInput {
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 16px 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  min-width: 0;
+}
+
+.recipientInput:focus {
+  outline: none;
+}
+
+.recipientInput::placeholder {
+  color: #656a8a;
   font-family: var(--font-sans);
   font-size: 13px;
 }
 
-.input:focus {
-  outline: none;
-  border-color: var(--teal);
+.pasteBtn {
+  background: none;
+  border: none;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--teal);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  padding: 0;
+  flex-shrink: 0;
 }
 
-.input.inputError {
-  border-color: var(--red);
+.pasteBtn:hover {
+  text-decoration: underline;
 }
 
-/* Amount row with MAX */
-.amountRow {
+.recipientHint {
+  font-size: 11px;
+  color: var(--green);
+  margin-top: 6px;
   display: flex;
   align-items: center;
-  gap: 0;
-  background: #0a0b14;
-  border: 1px solid var(--border-muted);
+  gap: 4px;
+}
+
+/* ── Amount input ── */
+.amountRow {
+  background: #1a1d2e;
+  border: 1px solid #353a5a;
   border-radius: 10px;
-  overflow: hidden;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 80px;
 }
 
 .amountRow:focus-within {
   border-color: var(--teal);
 }
 
-.amountRow.amountRowError {
-  border-color: var(--red);
-}
-
 .amountInput {
   flex: 1;
   background: none;
   border: none;
-  padding: 14px 16px;
   color: var(--text-primary);
-  font-size: 22px;
+  font-size: 28px;
   font-weight: 700;
   font-family: var(--font-mono);
   min-width: 0;
+  padding: 0;
 }
 
 .amountInput:focus {
@@ -219,33 +348,38 @@
 }
 
 .amountInput::placeholder {
-  color: var(--text-muted);
-  font-size: 15px;
-  font-weight: 400;
+  color: #353a5a;
+  font-size: 28px;
 }
 
 .maxBtn {
-  background: none;
-  border: none;
-  border-left: 1px solid var(--border);
-  padding: 0 18px;
-  height: 52px;
+  background: #232640;
+  border: 1px solid #353a5a;
+  border-radius: 6px;
+  padding: 4px 10px;
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.8px;
-  color: var(--teal);
+  font-weight: 600;
+  color: var(--text-primary);
   cursor: pointer;
   font-family: var(--font-sans);
   flex-shrink: 0;
 }
 
 .maxBtn:hover {
-  background: rgba(0, 212, 164, 0.06);
+  border-color: var(--teal);
+  color: var(--teal);
+}
+
+.amountSymbol {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  flex-shrink: 0;
 }
 
 .balanceHint {
   font-size: 11px;
-  color: var(--text-muted);
+  color: #656a8a;
   margin-top: 8px;
 }
 
@@ -253,9 +387,9 @@
 .infoStrip {
   display: flex;
   align-items: center;
-  gap: 8px;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border);
+  gap: 10px;
+  background: #12141f;
+  border: 1px solid #252840;
   border-radius: 10px;
   padding: 12px 16px;
   font-size: 12px;
@@ -268,7 +402,27 @@
   color: var(--text-muted);
 }
 
-/* Error banner */
+/* Continue button — inside card, full width */
+.btnContinue {
+  width: 100%;
+  height: 52px;
+  border-radius: 12px;
+  border: none;
+  background: var(--teal-gradient);
+  color: #0a0b14;
+  font-size: 15px;
+  font-weight: 700;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  margin-top: 24px;
+}
+
+.btnContinue:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Error banner ── */
 .errorBanner {
   background: rgba(255, 107, 107, 0.08);
   border: 1px solid rgba(255, 107, 107, 0.3);
@@ -279,60 +433,19 @@
   margin-bottom: 16px;
 }
 
-/* ── Actions ── */
-.actions {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.btnContinue {
-  height: 48px;
-  padding: 0 32px;
-  border-radius: 10px;
-  border: none;
-  background: var(--teal-gradient);
-  color: #0a0b14;
-  font-size: 14px;
-  font-weight: 700;
-  font-family: var(--font-sans);
-  cursor: pointer;
-}
-
-.btnContinue:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.btnBack {
-  background: none;
-  border: none;
-  font-size: 13px;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-family: var(--font-sans);
-  padding: 0;
-}
-
-.btnBack:hover {
-  color: var(--text-secondary);
-}
-
-/* ── Sign step ── */
+/* ── Sign card ── */
 .signCard {
-  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
-  border: 1px solid var(--teal);
+  background: linear-gradient(180deg, #1e2238 0%, #141729 100%);
+  border: 1.5px solid rgba(0, 212, 164, 0.4);
   border-radius: 16px;
-  padding: 40px 32px;
-  margin-bottom: 16px;
+  padding: 48px 32px 40px;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  box-shadow: 0 0 32px rgba(0, 212, 164, 0.08);
 }
 
-.signIcon {
+.signIconWrap {
   width: 64px;
   height: 64px;
   border-radius: 50%;
@@ -340,75 +453,109 @@
   align-items: center;
   justify-content: center;
   margin-bottom: 20px;
+  position: relative;
 }
 
 .signIconSnap {
-  background: rgba(0, 212, 164, 0.12);
+  background: rgba(0, 212, 164, 0.1);
   border: 1px solid rgba(0, 212, 164, 0.25);
 }
 
 .signIconMetaMask {
-  background: rgba(255, 107, 0, 0.1);
-  border: 1px solid rgba(255, 107, 0, 0.25);
+  background: rgba(246, 133, 27, 0.1);
+  border: 1px solid rgba(246, 133, 27, 0.25);
 }
 
 .signTitle {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 700;
   color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .signSubtitle {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-secondary);
   margin-bottom: 24px;
-  max-width: 420px;
+  max-width: 460px;
 }
 
+/* Hash preview — two-row layout */
 .hashPreview {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-muted);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 16px;
+  background: #0a0b14;
+  border: 1px solid #252840;
+  border-radius: 10px;
+  padding: 12px 20px 14px;
   margin-bottom: 24px;
-  word-break: break-all;
-  max-width: 100%;
-  text-align: left;
   width: 100%;
+  max-width: 576px;
   box-sizing: border-box;
+  text-align: left;
 }
 
-.contractPreview {
+.hashPreviewLabel {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: #656a8a;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.hashPreviewValue {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 14px 18px;
+  color: var(--text-primary);
+  word-break: break-all;
+  display: block;
+}
+
+/* Contract preview — two-row layout */
+.contractPreview {
+  background: #0a0b14;
+  border: 1px solid #252840;
+  border-radius: 10px;
+  padding: 12px 20px 14px;
   margin-bottom: 24px;
-  text-align: left;
   width: 100%;
+  max-width: 576px;
   box-sizing: border-box;
-  line-height: 1.6;
+  text-align: left;
+}
+
+.contractPreviewLabel {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: #656a8a;
+  display: block;
+  margin-bottom: 6px;
 }
 
 .contractCall {
-  color: var(--teal);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  word-break: break-all;
+  display: block;
+}
+
+.contractVia {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: #656a8a;
+  float: right;
 }
 
 .btnOpenDialog {
-  height: 48px;
-  padding: 0 32px;
-  border-radius: 10px;
+  height: 52px;
+  width: 100%;
+  max-width: 576px;
+  border-radius: 12px;
   border: none;
   background: var(--teal-gradient);
   color: #0a0b14;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 700;
   font-family: var(--font-sans);
   cursor: pointer;
@@ -420,41 +567,59 @@
   cursor: not-allowed;
 }
 
-.signStatus {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-  max-width: 320px;
-}
-
-.statusRow {
+/* Status row — horizontal */
+.signStatusRow {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 12px;
-  color: var(--text-muted);
+  gap: 20px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  max-width: 576px;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
-.statusDot {
-  width: 8px;
-  height: 8px;
+.statusItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.statusItemDot {
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.statusDotDone {
-  background: var(--green);
+.statusItemDotDone {
+  background: rgba(0, 212, 164, 0.2);
+  border: 1px solid #00d4a4;
 }
 
-.statusDotActive {
-  background: var(--teal);
-  box-shadow: 0 0 6px rgba(0, 212, 164, 0.6);
+.statusItemDotDone::after {
+  content: "";
+  display: block;
+  width: 5px;
+  height: 3px;
+  border-left: 1.5px solid #00d4a4;
+  border-bottom: 1.5px solid #00d4a4;
+  transform: rotate(-45deg) translate(0.5px, -0.5px);
+}
+
+.statusItemDotActive {
+  background: rgba(0, 212, 164, 0.15);
+  border: 1px solid #00d4a4;
   animation: pulse 1.4s ease-in-out infinite;
 }
 
-.statusDotPending {
-  background: var(--border-muted);
+.statusItemDotPending {
+  background: transparent;
+  border: 1px solid #353a5a;
 }
 
 @keyframes pulse {
@@ -462,32 +627,32 @@
   50% { opacity: 0.4; }
 }
 
-.statusDone {
-  color: var(--green);
+.statusItemDone {
+  color: var(--text-secondary);
 }
 
 .btnCancel {
   background: none;
   border: none;
   font-size: 12px;
-  color: var(--text-muted);
+  font-weight: 500;
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: var(--font-sans);
-  margin-top: 8px;
   padding: 0;
+  margin-left: auto;
 }
 
 .btnCancel:hover {
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
-/* ── Done step ── */
+/* ── Done card ── */
 .doneCard {
   background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 48px 32px;
-  margin-bottom: 16px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -495,90 +660,83 @@
 }
 
 .checkCircle {
-  width: 72px;
-  height: 72px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
-  background: rgba(0, 212, 164, 0.12);
-  border: 2px solid #00d4a4;
+  background: var(--teal-gradient);
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 20px;
-  box-shadow: 0 0 40px rgba(0, 212, 164, 0.2);
+  box-shadow: 0 0 48px rgba(0, 212, 164, 0.28);
 }
 
 .doneTitle {
-  font-size: 24px;
+  font-size: 26px;
   font-weight: 700;
   color: var(--text-primary);
   margin-bottom: 6px;
 }
 
 .doneSubtitle {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-secondary);
   margin-bottom: 32px;
 }
 
 .receipt {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border);
+  background: #0a0b14;
+  border: 1px solid #252840;
   border-radius: 12px;
-  padding: 20px 24px;
   width: 100%;
-  box-sizing: border-box;
-  max-width: 420px;
+  max-width: 576px;
   margin-bottom: 32px;
-  text-align: left;
+  overflow: hidden;
 }
 
 .receiptRow {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  padding: 8px 0;
-  font-size: 13px;
+  align-items: center;
+  padding: 18px 24px;
 }
 
 .receiptRow + .receiptRow {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid #252840;
 }
 
 .receiptLabel {
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.8px;
+  font-size: 12px;
+  color: #656a8a;
 }
 
 .receiptValue {
-  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
   text-align: right;
-  max-width: 220px;
+  max-width: 320px;
   word-break: break-all;
 }
 
 .receiptAmount {
-  color: var(--teal);
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 700;
+  font-family: var(--font-mono);
 }
 
 .doneActions {
   display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  justify-content: center;
+  gap: 16px;
 }
 
 .btnSendAnother {
+  width: 280px;
   height: 44px;
-  padding: 0 24px;
   border-radius: 10px;
-  border: 1px solid var(--border-muted);
-  background: transparent;
+  border: 1px solid #353a5a;
+  background: #232640;
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 600;
@@ -589,4 +747,17 @@
 .btnSendAnother:hover {
   border-color: var(--teal);
   color: var(--teal);
+}
+
+.btnViewActivity {
+  width: 280px;
+  height: 44px;
+  border-radius: 10px;
+  border: none;
+  background: var(--teal-gradient);
+  color: #0a0b14;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: var(--font-sans);
+  cursor: pointer;
 }

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -16,7 +16,7 @@
 .pageSubtitle {
   font-size: 13px;
   color: var(--text-secondary);
-  margin-bottom: 32px;
+  margin-bottom: 20px;
 }
 
 .modePill {
@@ -44,7 +44,10 @@
 .stepsBar {
   display: flex;
   align-items: center;
-  margin-bottom: 32px;
+  margin-bottom: 20px;
+  max-width: 768px;
+  margin-left: max(0px, calc(50% - 432px));
+  margin-right: auto;
 }
 
 .stepSegment {
@@ -130,11 +133,7 @@
 
 /* ── Form card ── */
 .card {
-  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
-  border: 1px solid var(--border);
-  border-radius: 16px;
   padding: 32px;
-  margin-bottom: 0;
 }
 
 .fieldLabel {
@@ -146,7 +145,7 @@
 }
 
 .fieldGroup {
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 }
 
 /* ── Token dropdown ── */
@@ -160,7 +159,7 @@
   border: 1px solid #353a5a;
   border-radius: 10px;
   padding: 0 16px;
-  height: 64px;
+  height: 56px;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -175,13 +174,13 @@
 }
 
 .tokenAvatar {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 13px;
   font-weight: 700;
   flex-shrink: 0;
 }
@@ -324,7 +323,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  height: 80px;
+  height: 56px;
 }
 
 .amountRow:focus-within {
@@ -336,7 +335,7 @@
   background: none;
   border: none;
   color: var(--text-primary);
-  font-size: 28px;
+  font-size: 18px;
   font-weight: 700;
   font-family: var(--font-mono);
   min-width: 0;
@@ -349,7 +348,7 @@
 
 .amountInput::placeholder {
   color: #353a5a;
-  font-size: 28px;
+  font-size: 18px;
 }
 
 .maxBtn {
@@ -431,6 +430,9 @@
   font-size: 13px;
   color: var(--red);
   margin-bottom: 16px;
+  max-width: 768px;
+  margin-left: max(0px, calc(50% - 432px));
+  margin-right: auto;
 }
 
 /* ── Sign card ── */
@@ -443,6 +445,9 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+  max-width: 768px;
+  margin-left: max(0px, calc(50% - 432px));
+  margin-right: auto;
 }
 
 .signIconWrap {
@@ -649,9 +654,6 @@
 
 /* ── Done card ── */
 .doneCard {
-  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
-  border: 1px solid var(--border);
-  border-radius: 16px;
   padding: 48px 32px;
   display: flex;
   flex-direction: column;

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -1,0 +1,592 @@
+/* ── Page header ── */
+.pageHeader {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 32px;
+}
+
+.pageTitle {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+  color: var(--text-primary);
+}
+
+.modePill {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.modePillCustodial {
+  background: rgba(139, 124, 255, 0.15);
+  color: #8b7cff;
+  border: 1px solid rgba(139, 124, 255, 0.3);
+}
+
+.modePillNonCustodial {
+  background: rgba(0, 212, 164, 0.12);
+  color: #00d4a4;
+  border: 1px solid rgba(0, 212, 164, 0.25);
+}
+
+/* ── Steps bar ── */
+.stepsBar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 32px;
+}
+
+.stepItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.stepDot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.stepDotPending {
+  background: transparent;
+  border: 2px solid var(--border-muted);
+  color: var(--text-muted);
+}
+
+.stepDotActive {
+  background: var(--teal-gradient);
+  border: 2px solid transparent;
+  color: #0a0b14;
+}
+
+.stepDotDone {
+  background: rgba(0, 212, 164, 0.15);
+  border: 2px solid #00d4a4;
+  color: #00d4a4;
+}
+
+.stepLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.stepLabelPending {
+  color: var(--text-muted);
+}
+
+.stepLabelActive {
+  color: var(--text-primary);
+}
+
+.stepLabelDone {
+  color: #00d4a4;
+}
+
+.stepConnector {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+  margin: 0 12px;
+  min-width: 32px;
+}
+
+/* ── Form card ── */
+.card {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 32px;
+  margin-bottom: 16px;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.fieldGroup {
+  margin-bottom: 24px;
+}
+
+.fieldGroup:last-child {
+  margin-bottom: 0;
+}
+
+/* Token selector */
+.tokenSelect {
+  width: 100%;
+  background: #0a0b14;
+  border: 1px solid var(--border-muted);
+  border-radius: 10px;
+  padding: 14px 16px;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%23656a8a' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+}
+
+.tokenSelect:focus {
+  outline: none;
+  border-color: var(--teal);
+}
+
+/* Text inputs */
+.input {
+  width: 100%;
+  background: #0a0b14;
+  border: 1px solid var(--border-muted);
+  border-radius: 10px;
+  padding: 14px 16px;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-family: var(--font-mono);
+  box-sizing: border-box;
+}
+
+.input::placeholder {
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--teal);
+}
+
+.input.inputError {
+  border-color: var(--red);
+}
+
+/* Amount row with MAX */
+.amountRow {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: #0a0b14;
+  border: 1px solid var(--border-muted);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.amountRow:focus-within {
+  border-color: var(--teal);
+}
+
+.amountRow.amountRowError {
+  border-color: var(--red);
+}
+
+.amountInput {
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 14px 16px;
+  color: var(--text-primary);
+  font-size: 22px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  min-width: 0;
+}
+
+.amountInput:focus {
+  outline: none;
+}
+
+.amountInput::placeholder {
+  color: var(--text-muted);
+  font-size: 15px;
+  font-weight: 400;
+}
+
+.maxBtn {
+  background: none;
+  border: none;
+  border-left: 1px solid var(--border);
+  padding: 0 18px;
+  height: 52px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  color: var(--teal);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  flex-shrink: 0;
+}
+
+.maxBtn:hover {
+  background: rgba(0, 212, 164, 0.06);
+}
+
+.balanceHint {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+
+/* Info strip */
+.infoStrip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 8px;
+}
+
+.infoStrip svg {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+/* Error banner */
+.errorBanner {
+  background: rgba(255, 107, 107, 0.08);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-size: 13px;
+  color: var(--red);
+  margin-bottom: 16px;
+}
+
+/* ── Actions ── */
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.btnContinue {
+  height: 48px;
+  padding: 0 32px;
+  border-radius: 10px;
+  border: none;
+  background: var(--teal-gradient);
+  color: #0a0b14;
+  font-size: 14px;
+  font-weight: 700;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.btnContinue:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btnBack {
+  background: none;
+  border: none;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  padding: 0;
+}
+
+.btnBack:hover {
+  color: var(--text-secondary);
+}
+
+/* ── Sign step ── */
+.signCard {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--teal);
+  border-radius: 16px;
+  padding: 40px 32px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  box-shadow: 0 0 32px rgba(0, 212, 164, 0.08);
+}
+
+.signIcon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.signIconSnap {
+  background: rgba(0, 212, 164, 0.12);
+  border: 1px solid rgba(0, 212, 164, 0.25);
+}
+
+.signIconMetaMask {
+  background: rgba(255, 107, 0, 0.1);
+  border: 1px solid rgba(255, 107, 0, 0.25);
+}
+
+.signTitle {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.signSubtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 24px;
+  max-width: 420px;
+}
+
+.hashPreview {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 16px;
+  margin-bottom: 24px;
+  word-break: break-all;
+  max-width: 100%;
+  text-align: left;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.contractPreview {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 18px;
+  margin-bottom: 24px;
+  text-align: left;
+  width: 100%;
+  box-sizing: border-box;
+  line-height: 1.6;
+}
+
+.contractCall {
+  color: var(--teal);
+}
+
+.btnOpenDialog {
+  height: 48px;
+  padding: 0 32px;
+  border-radius: 10px;
+  border: none;
+  background: var(--teal-gradient);
+  color: #0a0b14;
+  font-size: 14px;
+  font-weight: 700;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  margin-bottom: 20px;
+}
+
+.btnOpenDialog:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.signStatus {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.statusDotDone {
+  background: var(--green);
+}
+
+.statusDotActive {
+  background: var(--teal);
+  box-shadow: 0 0 6px rgba(0, 212, 164, 0.6);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.statusDotPending {
+  background: var(--border-muted);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.statusDone {
+  color: var(--green);
+}
+
+.btnCancel {
+  background: none;
+  border: none;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  margin-top: 8px;
+  padding: 0;
+}
+
+.btnCancel:hover {
+  color: var(--text-secondary);
+}
+
+/* ── Done step ── */
+.doneCard {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 48px 32px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.checkCircle {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: rgba(0, 212, 164, 0.12);
+  border: 2px solid #00d4a4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+  box-shadow: 0 0 40px rgba(0, 212, 164, 0.2);
+}
+
+.doneTitle {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.doneSubtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 32px;
+}
+
+.receipt {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px 24px;
+  width: 100%;
+  box-sizing: border-box;
+  max-width: 420px;
+  margin-bottom: 32px;
+  text-align: left;
+}
+
+.receiptRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 8px 0;
+  font-size: 13px;
+}
+
+.receiptRow + .receiptRow {
+  border-top: 1px solid var(--border);
+}
+
+.receiptLabel {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+}
+
+.receiptValue {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: right;
+  max-width: 220px;
+  word-break: break-all;
+}
+
+.receiptAmount {
+  color: var(--teal);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.doneActions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.btnSendAnother {
+  height: 44px;
+  padding: 0 24px;
+  border-radius: 10px;
+  border: 1px solid var(--border-muted);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.btnSendAnother:hover {
+  border-color: var(--teal);
+  color: var(--teal);
+}

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -286,7 +286,9 @@ export function TransferPage({
     }
 
     void load();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [currentNet.middlewareUrl, address]);
 
   // Auto-run prepare when entering sign step (non-custodial only).
@@ -302,7 +304,11 @@ export function TransferPage({
       setError(null);
       try {
         const result = await prepareTransfer(
-          currentNet.middlewareUrl, address, recipient, selectedToken.symbol, amount,
+          currentNet.middlewareUrl,
+          address,
+          recipient,
+          selectedToken.symbol,
+          amount,
         );
         if (cancelled) return;
         setPrepared(result);
@@ -318,7 +324,9 @@ export function TransferPage({
     }
 
     void prepare();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
 

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -1,12 +1,19 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
 import { Spinner } from "../components/Spinner";
 import { getNetwork, type NetworkId } from "../lib/config";
 import { getTokens, type TokenConfig } from "../lib/middleware";
-import { getTokenBalance, formatTokenAmount, encodeTransfer, parseTokenAmount, ethChainId } from "../lib/ethrpc";
+import {
+  getTokenBalance,
+  formatTokenAmount,
+  encodeTransfer,
+  parseTokenAmount,
+  ethChainId,
+} from "../lib/ethrpc";
 import { prepareTransfer, executeTransfer, type PrepareResult } from "../lib/transfer";
 import { addEthChain, sendEthTransaction, shortenAddress } from "../lib/ethereum";
+import { TOKEN_COLORS } from "../lib/tokens";
 import { useSnap } from "../hooks/useSnap";
 import { cn } from "../lib/cn";
 import styles from "./TransferPage.module.css";
@@ -31,30 +38,29 @@ interface Props {
   keyMode: "custodial" | "external";
 }
 
-function CheckIcon() {
+function TokenAvatar({ symbol }: { symbol: string }) {
+  const colors = TOKEN_COLORS[symbol.toUpperCase()] ?? { bg: "#656a8a", text: "#ffffff" };
   return (
-    <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
-      <path d="M8 16L13 21L24 11" stroke="#00d4a4" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+    <div className={styles.tokenAvatar} style={{ background: colors.bg, color: colors.text }}>
+      {symbol.charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
+function ChevronDown() {
+  return (
+    <svg width="10" height="6" viewBox="0 0 10 6" fill="none" className={styles.tokenDropdownChevron}>
+      <path d="M1 1L5 5L9 1" stroke="#a1a6c4" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   );
 }
 
-function SnapIcon() {
+function InfoIcon() {
   return (
-    <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
-      <path d="M14 4L24 9.5V18.5L14 24L4 18.5V9.5L14 4Z" stroke="#00d4a4" strokeWidth="1.8" strokeLinejoin="round" />
-      <path d="M14 10V14L17 16" stroke="#00d4a4" strokeWidth="1.6" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function MetaMaskIcon() {
-  return (
-    <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
-      <circle cx="14" cy="14" r="10" fill="rgba(255,107,0,0.15)" />
-      <path d="M9 10L14 7L19 10L14 13L9 10Z" fill="#ff6b00" opacity="0.8" />
-      <path d="M9 10V18L14 21V13L9 10Z" fill="#ff6b00" opacity="0.5" />
-      <path d="M19 10V18L14 21V13L19 10Z" fill="#ff6b00" opacity="0.7" />
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <circle cx="7" cy="7" r="6" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M7 6V10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+      <circle cx="7" cy="4" r="0.7" fill="currentColor" />
     </svg>
   );
 }
@@ -62,7 +68,7 @@ function MetaMaskIcon() {
 type StepState = "pending" | "active" | "done";
 
 function StepsBar({ step }: { step: Step }) {
-  const steps: { id: Step; label: string }[] = [
+  const items: { id: Step; label: string }[] = [
     { id: "details", label: "Details" },
     { id: "sign", label: "Sign" },
     { id: "done", label: "Done" },
@@ -79,10 +85,11 @@ function StepsBar({ step }: { step: Step }) {
 
   return (
     <div className={styles.stepsBar}>
-      {steps.map(({ id, label }, i) => {
+      {items.map(({ id, label }, i) => {
         const st = state(id);
+        const connectorDone = i < current;
         return (
-          <div key={id} style={{ display: "flex", alignItems: "center", flex: i < steps.length - 1 ? 1 : undefined }}>
+          <div key={id} className={cn(styles.stepSegment, i === items.length - 1 ? "" : "")}>
             <div className={styles.stepItem}>
               <div
                 className={cn(
@@ -92,7 +99,19 @@ function StepsBar({ step }: { step: Step }) {
                   st === "pending" && styles.stepDotPending,
                 )}
               >
-                {st === "done" ? "✓" : i + 1}
+                {st === "done" ? (
+                  <svg width="14" height="10" viewBox="0 0 14 10" fill="none">
+                    <path
+                      d="M1 5L5 9L13 1"
+                      stroke="#00d4a4"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                ) : (
+                  i + 1
+                )}
               </div>
               <span
                 className={cn(
@@ -105,10 +124,95 @@ function StepsBar({ step }: { step: Step }) {
                 {label}
               </span>
             </div>
-            {i < steps.length - 1 && <div className={styles.stepConnector} />}
+            {i < items.length - 1 && (
+              <div
+                className={cn(
+                  styles.stepConnector,
+                  connectorDone ? styles.stepConnectorDone : styles.stepConnectorPending,
+                )}
+              />
+            )}
           </div>
         );
       })}
+    </div>
+  );
+}
+
+interface TokenDropdownProps {
+  tokens: TokenConfig[];
+  selected: TokenConfig | null;
+  balances: Map<string, bigint>;
+  onSelect: (t: TokenConfig) => void;
+}
+
+function TokenDropdown({ tokens, selected, balances, onSelect }: TokenDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onOutside);
+    return () => document.removeEventListener("mousedown", onOutside);
+  }, []);
+
+  const bal = selected ? balances.get(selected.address) : undefined;
+
+  return (
+    <div className={styles.tokenDropdownWrapper} ref={ref}>
+      <button
+        type="button"
+        className={styles.tokenDropdownTrigger}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {selected ? (
+          <>
+            <TokenAvatar symbol={selected.symbol} />
+            <div className={styles.tokenDropdownInfo}>
+              <span className={styles.tokenDropdownName}>{selected.symbol}</span>
+              <span className={styles.tokenDropdownBalance}>
+                {bal !== undefined
+                  ? `Balance: ${formatTokenAmount(bal, selected.decimals)}`
+                  : "Loading balance…"}
+              </span>
+            </div>
+          </>
+        ) : (
+          <span className={styles.tokenDropdownName} style={{ color: "#656a8a" }}>
+            Select token
+          </span>
+        )}
+        <ChevronDown />
+      </button>
+
+      {open && (
+        <div className={styles.tokenDropdownMenu}>
+          {tokens.map((t) => {
+            const b = balances.get(t.address);
+            return (
+              <button
+                key={t.address}
+                type="button"
+                className={styles.tokenDropdownItem}
+                onClick={() => {
+                  onSelect(t);
+                  setOpen(false);
+                }}
+              >
+                <TokenAvatar symbol={t.symbol} />
+                <div>
+                  <span className={styles.tokenDropdownItemName}>{t.symbol}</span>
+                  <span className={styles.tokenDropdownItemBalance}>
+                    {b !== undefined ? `Balance: ${formatTokenAmount(b, t.decimals)}` : t.name}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -126,9 +230,9 @@ export function TransferPage({
   const [tokens, setTokens] = useState<TokenConfig[]>([]);
   const [tokensLoading, setTokensLoading] = useState(true);
   const [selectedToken, setSelectedToken] = useState<TokenConfig | null>(null);
+  const [balances, setBalances] = useState<Map<string, bigint>>(new Map());
   const [recipient, setRecipient] = useState("");
   const [amount, setAmount] = useState("");
-  const [balance, setBalance] = useState<bigint | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [signPhase, setSignPhase] = useState<SignPhase>("idle");
@@ -139,28 +243,31 @@ export function TransferPage({
   const isNonCustodial = keyMode === "external";
   const currentNet = getNetwork(network);
 
-  // Load token list
+  // Load token list then fetch all balances
   useEffect(() => {
     setTokensLoading(true);
+    const rpcUrl = `${currentNet.middlewareUrl}/eth`;
     getTokens(currentNet.middlewareUrl)
-      .then((list) => {
+      .then(async (list) => {
         setTokens(list);
         if (list.length > 0) setSelectedToken(list[0]);
+        const entries = await Promise.all(
+          list.map(async (t) => {
+            try {
+              const b = await getTokenBalance(rpcUrl, t.address, address);
+              return [t.address, b] as [string, bigint];
+            } catch {
+              return [t.address, 0n] as [string, bigint];
+            }
+          }),
+        );
+        setBalances(new Map(entries));
       })
       .catch(() => {})
       .finally(() => setTokensLoading(false));
-  }, [currentNet.middlewareUrl]);
+  }, [currentNet.middlewareUrl, address]);
 
-  // Load balance whenever selected token or address changes
-  useEffect(() => {
-    if (!selectedToken) { setBalance(null); return; }
-    const rpcUrl = `${currentNet.middlewareUrl}/eth`;
-    getTokenBalance(rpcUrl, selectedToken.address, address)
-      .then(setBalance)
-      .catch(() => setBalance(null));
-  }, [selectedToken, currentNet.middlewareUrl, address]);
-
-  // Auto-run prepare when entering sign step (non-custodial)
+  // Auto-run prepare when entering sign step (non-custodial only)
   useEffect(() => {
     if (step !== "sign" || !isNonCustodial || !selectedToken) return;
     let cancelled = false;
@@ -184,16 +291,18 @@ export function TransferPage({
         if (!cancelled) setPending(false);
       });
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [step]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function validate(): string | null {
     if (!selectedToken) return "Select a token";
     if (!recipient.match(/^0x[0-9a-fA-F]{40}$/)) return "Enter a valid 0x EVM address";
     if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) return "Enter a positive amount";
-    if (balance !== null) {
-      const parsed = parseTokenAmount(amount, selectedToken.decimals);
-      if (parsed > balance) return "Amount exceeds your balance";
+    const bal = balances.get(selectedToken.address);
+    if (bal !== undefined) {
+      if (parseTokenAmount(amount, selectedToken.decimals) > bal) return "Amount exceeds your balance";
     }
     return null;
   }
@@ -205,7 +314,6 @@ export function TransferPage({
     setStep("sign");
   }
 
-  // Non-custodial: snap sign + execute (prepare already done on step entry)
   async function handleSnapSign() {
     if (!prepared || !selectedToken) return;
     setPending(true);
@@ -239,7 +347,6 @@ export function TransferPage({
     }
   }
 
-  // Custodial: add Canton chain to MetaMask, then send via eth_sendTransaction
   async function handleMetaMaskSign() {
     if (!selectedToken) return;
     setPending(true);
@@ -278,8 +385,18 @@ export function TransferPage({
     setReceipt(null);
   }
 
+  async function handlePaste() {
+    try {
+      const text = await navigator.clipboard.readText();
+      setRecipient(text.trim());
+    } catch {
+      // clipboard access denied — no-op
+    }
+  }
+
+  const recipientValid = /^0x[0-9a-fA-F]{40}$/.test(recipient);
+  const selectedBalance = selectedToken ? balances.get(selectedToken.address) : undefined;
   const pillClass = isNonCustodial ? styles.modePillNonCustodial : styles.modePillCustodial;
-  const pillLabel = isNonCustodial ? "NON-CUSTODIAL" : "CUSTODIAL";
 
   return (
     <>
@@ -295,254 +412,277 @@ export function TransferPage({
         {/* Header */}
         <div className={styles.pageHeader}>
           <h1 className={styles.pageTitle}>Transfer</h1>
-          <span className={cn(styles.modePill, pillClass)}>{pillLabel}</span>
+          <span className={cn(styles.modePill, pillClass)}>
+            {isNonCustodial ? "NON-CUSTODIAL" : "CUSTODIAL"}
+          </span>
         </div>
+        <p className={styles.pageSubtitle}>Send tokens on Canton Network.</p>
 
         <StepsBar step={step} />
 
-        {/* Error banner */}
         {error && <div className={styles.errorBanner}>{error}</div>}
 
         {/* ── Details step ── */}
         {step === "details" && (
-          <>
-            <div className={styles.card}>
-              {/* Token selector */}
-              <div className={styles.fieldGroup}>
-                <p className={styles.fieldLabel}>TOKEN</p>
-                {tokensLoading ? (
-                  <Spinner />
-                ) : (
-                  <select
-                    className={styles.tokenSelect}
-                    value={selectedToken?.address ?? ""}
-                    onChange={(e) => {
-                      const t = tokens.find((tk) => tk.address === e.target.value) ?? null;
-                      setSelectedToken(t);
-                      setAmount("");
-                    }}
-                  >
-                    {tokens.map((t) => (
-                      <option key={t.address} value={t.address}>
-                        {t.symbol} — {t.name}
-                      </option>
-                    ))}
-                  </select>
-                )}
-              </div>
+          <div className={styles.card}>
+            {/* Token */}
+            <div className={styles.fieldGroup}>
+              <p className={styles.fieldLabel}>TOKEN</p>
+              {tokensLoading ? (
+                <Spinner />
+              ) : (
+                <TokenDropdown
+                  tokens={tokens}
+                  selected={selectedToken}
+                  balances={balances}
+                  onSelect={(t) => {
+                    setSelectedToken(t);
+                    setAmount("");
+                  }}
+                />
+              )}
+            </div>
 
-              {/* Recipient */}
-              <div className={styles.fieldGroup}>
-                <p className={styles.fieldLabel}>RECIPIENT</p>
+            {/* Recipient */}
+            <div className={styles.fieldGroup}>
+              <p className={styles.fieldLabel}>RECIPIENT</p>
+              <div className={styles.recipientWrapper}>
                 <input
-                  className={styles.input}
+                  className={styles.recipientInput}
                   type="text"
                   placeholder="0x..."
                   value={recipient}
                   onChange={(e) => setRecipient(e.target.value.trim())}
                   spellCheck={false}
                 />
+                <button className={styles.pasteBtn} type="button" onClick={handlePaste}>
+                  Paste
+                </button>
               </div>
+              {recipientValid && (
+                <p className={styles.recipientHint}>✓ Registered Canton party</p>
+              )}
+            </div>
 
-              {/* Amount */}
-              <div className={styles.fieldGroup}>
-                <p className={styles.fieldLabel}>AMOUNT</p>
-                <div className={styles.amountRow}>
-                  <input
-                    className={styles.amountInput}
-                    type="text"
-                    inputMode="decimal"
-                    placeholder="0"
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
-                  />
-                  {balance !== null && selectedToken && (
-                    <button
-                      className={styles.maxBtn}
-                      onClick={() => setAmount(formatTokenAmount(balance, selectedToken.decimals))}
-                      type="button"
-                    >
-                      MAX
-                    </button>
-                  )}
-                </div>
-                {balance !== null && selectedToken && (
-                  <p className={styles.balanceHint}>
-                    Balance: {formatTokenAmount(balance, selectedToken.decimals)} {selectedToken.symbol}
-                  </p>
+            {/* Amount */}
+            <div className={styles.fieldGroup}>
+              <p className={styles.fieldLabel}>AMOUNT</p>
+              <div className={styles.amountRow}>
+                <input
+                  className={styles.amountInput}
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                />
+                {selectedBalance !== undefined && selectedToken && (
+                  <button
+                    className={styles.maxBtn}
+                    type="button"
+                    onClick={() => setAmount(formatTokenAmount(selectedBalance, selectedToken.decimals))}
+                  >
+                    MAX
+                  </button>
+                )}
+                {selectedToken && (
+                  <span className={styles.amountSymbol}>{selectedToken.symbol}</span>
                 )}
               </div>
-
-              {/* Info strip */}
-              <div className={styles.infoStrip}>
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                  <circle cx="7" cy="7" r="6" stroke="currentColor" strokeWidth="1.4" />
-                  <path d="M7 6V10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-                  <circle cx="7" cy="4" r="0.7" fill="currentColor" />
-                </svg>
-                {isNonCustodial
-                  ? "Gas-free on Canton · Settles in ~2–4s · You'll sign twice (MetaMask + Snap)"
-                  : "Gas-free on Canton · Settles in ~2–4s · One MetaMask confirmation"}
-              </div>
+              {selectedBalance !== undefined && selectedToken && (
+                <p className={styles.balanceHint}>
+                  Balance: {formatTokenAmount(selectedBalance, selectedToken.decimals)}{" "}
+                  {selectedToken.symbol}
+                </p>
+              )}
             </div>
 
-            <div className={styles.actions}>
-              <button className={styles.btnContinue} onClick={handleContinue}>
-                Continue
-              </button>
+            {/* Info strip */}
+            <div className={styles.infoStrip}>
+              <InfoIcon />
+              {isNonCustodial ? (
+                <span>
+                  Gas-free on Canton · Settles in ~2–4s · You&apos;ll sign{" "}
+                  <strong style={{ color: "var(--text-primary)" }}>twice</strong> (MetaMask + Snap)
+                </span>
+              ) : (
+                <span>
+                  Gas-free on Canton · Settles in ~2–4s ·{" "}
+                  <strong style={{ color: "var(--text-primary)" }}>one MetaMask signature</strong>{" "}
+                  — server co-signs Canton side
+                </span>
+              )}
             </div>
-          </>
+
+            <button className={styles.btnContinue} onClick={handleContinue}>
+              Continue
+            </button>
+          </div>
         )}
 
         {/* ── Sign step (non-custodial) ── */}
         {step === "sign" && isNonCustodial && (
-          <>
-            <div className={styles.signCard}>
-              <div className={cn(styles.signIcon, styles.signIconSnap)}>
-                {pending && signPhase !== "awaiting-snap" ? <Spinner /> : <SnapIcon />}
-              </div>
-
-              <p className={styles.signTitle}>Sign in Canton Snap</p>
-              <p className={styles.signSubtitle}>
-                {signPhase === "preparing"
-                  ? "Authenticating with MetaMask…"
-                  : "Review the transfer in your Canton Snap, then approve."}
-              </p>
-
-              {prepared && (
-                <div className={styles.hashPreview}>
-                  <span style={{ color: "var(--text-muted)", fontSize: 10, letterSpacing: 1 }}>TX HASH </span>
-                  {prepared.transactionHash}
-                </div>
+          <div className={styles.signCard}>
+            <div className={cn(styles.signIconWrap, styles.signIconSnap)}>
+              {pending && signPhase !== "awaiting-snap" ? (
+                <Spinner />
+              ) : (
+                <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+                  <path
+                    d="M14 4L24 9.5V18.5L14 24L4 18.5V9.5L14 4Z"
+                    stroke="#00d4a4"
+                    strokeWidth="1.8"
+                    strokeLinejoin="round"
+                  />
+                  <path d="M9 14L12 17L19 11" stroke="#00d4a4" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
               )}
+            </div>
 
-              <button
-                className={styles.btnOpenDialog}
-                onClick={handleSnapSign}
-                disabled={pending || signPhase !== "awaiting-snap"}
-              >
-                {pending && signPhase === "signing" ? "Signing…" : "Open snap dialog"}
-              </button>
+            <p className={styles.signTitle}>Sign in Canton Snap</p>
+            <p className={styles.signSubtitle}>
+              {signPhase === "preparing"
+                ? "Authenticating with MetaMask…"
+                : "Review the transaction hash in the snap dialog and approve to send the transfer."}
+            </p>
 
-              <div className={styles.signStatus}>
-                <div className={styles.statusRow}>
-                  <span
-                    className={cn(
-                      styles.statusDot,
-                      signPhase === "preparing" ? styles.statusDotActive : styles.statusDotDone,
-                    )}
-                  />
-                  <span className={signPhase !== "preparing" ? styles.statusDone : ""}>
-                    Authenticated with MetaMask
-                  </span>
-                </div>
-                <div className={styles.statusRow}>
-                  <span
-                    className={cn(
-                      styles.statusDot,
-                      signPhase === "preparing"
-                        ? styles.statusDotPending
-                        : signPhase === "awaiting-snap"
-                          ? styles.statusDotDone
-                          : styles.statusDotDone,
-                    )}
-                  />
-                  <span className={prepared ? styles.statusDone : ""}>Transaction prepared</span>
-                </div>
-                <div className={styles.statusRow}>
-                  <span
-                    className={cn(
-                      styles.statusDot,
-                      signPhase === "signing" || signPhase === "executing"
-                        ? styles.statusDotActive
-                        : styles.statusDotPending,
-                    )}
-                  />
-                  <span>Canton Snap signing</span>
-                </div>
+            {prepared && (
+              <div className={styles.hashPreview}>
+                <span className={styles.hashPreviewLabel}>TRANSACTION HASH</span>
+                <span className={styles.hashPreviewValue}>{prepared.transactionHash}</span>
               </div>
+            )}
 
+            <button
+              className={styles.btnOpenDialog}
+              onClick={handleSnapSign}
+              disabled={pending || signPhase !== "awaiting-snap"}
+            >
+              {pending && signPhase === "signing" ? "Signing…" : "Open snap dialog"}
+            </button>
+
+            <div className={styles.signStatusRow}>
+              <div className={styles.statusItem}>
+                <div
+                  className={cn(
+                    styles.statusItemDot,
+                    signPhase === "preparing"
+                      ? styles.statusItemDotActive
+                      : styles.statusItemDotDone,
+                  )}
+                />
+                <span className={styles.statusItemDone}>Authenticated with MetaMask</span>
+              </div>
+              <div className={styles.statusItem}>
+                <div
+                  className={cn(
+                    styles.statusItemDot,
+                    signPhase === "preparing"
+                      ? styles.statusItemDotPending
+                      : styles.statusItemDotDone,
+                  )}
+                />
+                <span className={prepared ? styles.statusItemDone : ""}>Transaction prepared</span>
+              </div>
               <button className={styles.btnCancel} onClick={handleReset}>
                 Cancel
               </button>
             </div>
-          </>
+          </div>
         )}
 
         {/* ── Sign step (custodial) ── */}
         {step === "sign" && !isNonCustodial && selectedToken && (
-          <>
-            <div className={styles.signCard}>
-              <div className={cn(styles.signIcon, styles.signIconMetaMask)}>
-                {pending ? <Spinner /> : <MetaMaskIcon />}
+          <div className={styles.signCard}>
+            <div className={cn(styles.signIconWrap, styles.signIconMetaMask)}>
+              {pending ? (
+                <Spinner />
+              ) : (
+                <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+                  <path
+                    d="M14 3L25 8.5V19.5L14 25L3 19.5V8.5L14 3Z"
+                    fill="rgba(246,133,27,0.2)"
+                    stroke="#f6851b"
+                    strokeWidth="1.6"
+                    strokeLinejoin="round"
+                  />
+                  <circle cx="14" cy="14" r="3.5" fill="#f6851b" opacity="0.8" />
+                </svg>
+              )}
+            </div>
+
+            <p className={styles.signTitle}>Confirm in MetaMask</p>
+            <p className={styles.signSubtitle}>
+              Sign the ERC-20 transfer — the middleware will co-sign on Canton.
+            </p>
+
+            <div className={styles.contractPreview}>
+              <span className={styles.contractPreviewLabel}>
+                CONTRACT CALL
+                <span className={styles.contractVia}>via /eth</span>
+              </span>
+              <span className={styles.contractCall}>
+                {selectedToken.symbol.toLowerCase()}.transfer({shortenAddress(recipient)},{" "}
+                {parseTokenAmount(amount, selectedToken.decimals).toString()})
+              </span>
+            </div>
+
+            <button className={styles.btnOpenDialog} onClick={handleMetaMaskSign} disabled={pending}>
+              {pending ? "Waiting for MetaMask…" : "Open MetaMask"}
+            </button>
+
+            <div className={styles.signStatusRow}>
+              <div className={styles.statusItem}>
+                <div
+                  className={cn(
+                    styles.statusItemDot,
+                    pending ? styles.statusItemDotActive : styles.statusItemDotPending,
+                  )}
+                />
+                <span>Custodial mode — no Canton Snap required</span>
               </div>
-
-              <p className={styles.signTitle}>Confirm in MetaMask</p>
-              <p className={styles.signSubtitle}>
-                Custodial mode — no Canton Snap required. The server co-signs the Canton side.
-              </p>
-
-              <div className={styles.contractPreview}>
-                <span className={styles.contractCall}>
-                  {selectedToken.symbol.toLowerCase()}.transfer(
-                  {shortenAddress(recipient)}, {parseTokenAmount(amount, selectedToken.decimals).toString()})
-                </span>
-                {" "}via /eth
-              </div>
-
-              <button
-                className={styles.btnOpenDialog}
-                onClick={handleMetaMaskSign}
-                disabled={pending}
-              >
-                {pending ? "Waiting for MetaMask…" : "Open MetaMask"}
-              </button>
-
-              <div className={styles.signStatus}>
-                <div className={styles.statusRow}>
-                  <span className={cn(styles.statusDot, pending ? styles.statusDotActive : styles.statusDotPending)} />
-                  <span>MetaMask confirmation</span>
-                </div>
-                <div className={styles.statusRow}>
-                  <span className={cn(styles.statusDot, styles.statusDotPending)} />
-                  <span>Server signs Canton side</span>
-                </div>
-              </div>
-
               <button className={styles.btnCancel} onClick={handleReset}>
                 Cancel
               </button>
             </div>
-          </>
+          </div>
         )}
 
         {/* ── Done step ── */}
         {step === "done" && receipt && (
           <div className={styles.doneCard}>
             <div className={styles.checkCircle}>
-              <CheckIcon />
+              <svg width="28" height="20" viewBox="0 0 28 20" fill="none">
+                <path
+                  d="M2 10L10 18L26 2"
+                  stroke="#0a0b14"
+                  strokeWidth="3.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
             </div>
 
             <p className={styles.doneTitle}>Transfer sent</p>
-            <p className={styles.doneSubtitle}>Settled on Canton in under 4 seconds.</p>
+            <p className={styles.doneSubtitle}>Transfer confirmed on Canton Network.</p>
 
             <div className={styles.receipt}>
               <div className={styles.receiptRow}>
-                <span className={styles.receiptLabel}>AMOUNT</span>
+                <span className={styles.receiptLabel}>Amount</span>
                 <span className={cn(styles.receiptValue, styles.receiptAmount)}>
                   {receipt.amount} {receipt.token.symbol}
                 </span>
               </div>
               <div className={styles.receiptRow}>
-                <span className={styles.receiptLabel}>TO</span>
+                <span className={styles.receiptLabel}>To</span>
                 <span className={styles.receiptValue}>{receipt.to}</span>
               </div>
               <div className={styles.receiptRow}>
-                <span className={styles.receiptLabel}>TX HASH</span>
+                <span className={styles.receiptLabel}>Transaction</span>
                 <span className={styles.receiptValue}>{receipt.txHash}</span>
               </div>
               <div className={styles.receiptRow}>
-                <span className={styles.receiptLabel}>COMPLETED</span>
+                <span className={styles.receiptLabel}>Completed</span>
                 <span className={styles.receiptValue}>Just now</span>
               </div>
             </div>
@@ -550,6 +690,12 @@ export function TransferPage({
             <div className={styles.doneActions}>
               <button className={styles.btnSendAnother} onClick={handleReset}>
                 Send another
+              </button>
+              <button
+                className={styles.btnViewActivity}
+                onClick={() => onTabChange("balances")}
+              >
+                View in Activity →
               </button>
             </div>
           </div>

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -1,0 +1,560 @@
+import { useState, useEffect } from "react";
+import { AmbientOrb } from "../components/AmbientOrb";
+import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
+import { Spinner } from "../components/Spinner";
+import { getNetwork, type NetworkId } from "../lib/config";
+import { getTokens, type TokenConfig } from "../lib/middleware";
+import { getTokenBalance, formatTokenAmount, encodeTransfer, parseTokenAmount, ethChainId } from "../lib/ethrpc";
+import { prepareTransfer, executeTransfer, type PrepareResult } from "../lib/transfer";
+import { addEthChain, sendEthTransaction, shortenAddress } from "../lib/ethereum";
+import { useSnap } from "../hooks/useSnap";
+import { cn } from "../lib/cn";
+import styles from "./TransferPage.module.css";
+
+type Step = "details" | "sign" | "done";
+type SignPhase = "idle" | "preparing" | "awaiting-snap" | "signing" | "executing";
+
+interface Receipt {
+  txHash: string;
+  token: TokenConfig;
+  amount: string;
+  to: string;
+}
+
+interface Props {
+  address: string;
+  network: NetworkId;
+  onNetworkChange: (id: NetworkId) => void;
+  activeTab: DashboardTab;
+  onTabChange: (tab: DashboardTab) => void;
+  onDisconnect: () => void;
+  keyMode: "custodial" | "external";
+}
+
+function CheckIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+      <path d="M8 16L13 21L24 11" stroke="#00d4a4" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function SnapIcon() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+      <path d="M14 4L24 9.5V18.5L14 24L4 18.5V9.5L14 4Z" stroke="#00d4a4" strokeWidth="1.8" strokeLinejoin="round" />
+      <path d="M14 10V14L17 16" stroke="#00d4a4" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MetaMaskIcon() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+      <circle cx="14" cy="14" r="10" fill="rgba(255,107,0,0.15)" />
+      <path d="M9 10L14 7L19 10L14 13L9 10Z" fill="#ff6b00" opacity="0.8" />
+      <path d="M9 10V18L14 21V13L9 10Z" fill="#ff6b00" opacity="0.5" />
+      <path d="M19 10V18L14 21V13L19 10Z" fill="#ff6b00" opacity="0.7" />
+    </svg>
+  );
+}
+
+type StepState = "pending" | "active" | "done";
+
+function StepsBar({ step }: { step: Step }) {
+  const steps: { id: Step; label: string }[] = [
+    { id: "details", label: "Details" },
+    { id: "sign", label: "Sign" },
+    { id: "done", label: "Done" },
+  ];
+  const order: Step[] = ["details", "sign", "done"];
+  const current = order.indexOf(step);
+
+  function state(s: Step): StepState {
+    const i = order.indexOf(s);
+    if (i < current) return "done";
+    if (i === current) return "active";
+    return "pending";
+  }
+
+  return (
+    <div className={styles.stepsBar}>
+      {steps.map(({ id, label }, i) => {
+        const st = state(id);
+        return (
+          <div key={id} style={{ display: "flex", alignItems: "center", flex: i < steps.length - 1 ? 1 : undefined }}>
+            <div className={styles.stepItem}>
+              <div
+                className={cn(
+                  styles.stepDot,
+                  st === "done" && styles.stepDotDone,
+                  st === "active" && styles.stepDotActive,
+                  st === "pending" && styles.stepDotPending,
+                )}
+              >
+                {st === "done" ? "✓" : i + 1}
+              </div>
+              <span
+                className={cn(
+                  styles.stepLabel,
+                  st === "done" && styles.stepLabelDone,
+                  st === "active" && styles.stepLabelActive,
+                  st === "pending" && styles.stepLabelPending,
+                )}
+              >
+                {label}
+              </span>
+            </div>
+            {i < steps.length - 1 && <div className={styles.stepConnector} />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function TransferPage({
+  address,
+  network,
+  onNetworkChange,
+  activeTab,
+  onTabChange,
+  onDisconnect,
+  keyMode,
+}: Props) {
+  const [step, setStep] = useState<Step>("details");
+  const [tokens, setTokens] = useState<TokenConfig[]>([]);
+  const [tokensLoading, setTokensLoading] = useState(true);
+  const [selectedToken, setSelectedToken] = useState<TokenConfig | null>(null);
+  const [recipient, setRecipient] = useState("");
+  const [amount, setAmount] = useState("");
+  const [balance, setBalance] = useState<bigint | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [signPhase, setSignPhase] = useState<SignPhase>("idle");
+  const [prepared, setPrepared] = useState<PrepareResult | null>(null);
+  const [receipt, setReceipt] = useState<Receipt | null>(null);
+
+  const snap = useSnap();
+  const isNonCustodial = keyMode === "external";
+  const currentNet = getNetwork(network);
+
+  // Load token list
+  useEffect(() => {
+    setTokensLoading(true);
+    getTokens(currentNet.middlewareUrl)
+      .then((list) => {
+        setTokens(list);
+        if (list.length > 0) setSelectedToken(list[0]);
+      })
+      .catch(() => {})
+      .finally(() => setTokensLoading(false));
+  }, [currentNet.middlewareUrl]);
+
+  // Load balance whenever selected token or address changes
+  useEffect(() => {
+    if (!selectedToken) { setBalance(null); return; }
+    const rpcUrl = `${currentNet.middlewareUrl}/eth`;
+    getTokenBalance(rpcUrl, selectedToken.address, address)
+      .then(setBalance)
+      .catch(() => setBalance(null));
+  }, [selectedToken, currentNet.middlewareUrl, address]);
+
+  // Auto-run prepare when entering sign step (non-custodial)
+  useEffect(() => {
+    if (step !== "sign" || !isNonCustodial || !selectedToken) return;
+    let cancelled = false;
+    setSignPhase("preparing");
+    setPending(true);
+    setError(null);
+
+    prepareTransfer(currentNet.middlewareUrl, address, recipient, selectedToken.symbol, amount)
+      .then((result) => {
+        if (cancelled) return;
+        setPrepared(result);
+        setSignPhase("awaiting-snap");
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError((e as Error).message);
+        setStep("details");
+        setSignPhase("idle");
+      })
+      .finally(() => {
+        if (!cancelled) setPending(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [step]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function validate(): string | null {
+    if (!selectedToken) return "Select a token";
+    if (!recipient.match(/^0x[0-9a-fA-F]{40}$/)) return "Enter a valid 0x EVM address";
+    if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) return "Enter a positive amount";
+    if (balance !== null) {
+      const parsed = parseTokenAmount(amount, selectedToken.decimals);
+      if (parsed > balance) return "Amount exceeds your balance";
+    }
+    return null;
+  }
+
+  function handleContinue() {
+    const err = validate();
+    if (err) { setError(err); return; }
+    setError(null);
+    setStep("sign");
+  }
+
+  // Non-custodial: snap sign + execute (prepare already done on step entry)
+  async function handleSnapSign() {
+    if (!prepared || !selectedToken) return;
+    setPending(true);
+    setError(null);
+    try {
+      setSignPhase("signing");
+      const { derSignature, fingerprint } = await snap.signHash(prepared.transactionHash, {
+        operation: "transfer",
+        tokenSymbol: selectedToken.symbol,
+        amount,
+        recipient,
+        sender: address,
+      });
+
+      setSignPhase("executing");
+      await executeTransfer(
+        currentNet.middlewareUrl,
+        address,
+        prepared.transferId,
+        derSignature,
+        fingerprint,
+      );
+
+      setReceipt({ txHash: prepared.transactionHash, token: selectedToken, amount, to: recipient });
+      setStep("done");
+    } catch (e: unknown) {
+      setError((e as Error).message);
+      setSignPhase("awaiting-snap");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  // Custodial: add Canton chain to MetaMask, then send via eth_sendTransaction
+  async function handleMetaMaskSign() {
+    if (!selectedToken) return;
+    setPending(true);
+    setError(null);
+    try {
+      const rpcUrl = `${currentNet.middlewareUrl}/eth`;
+      const chainId = await ethChainId(rpcUrl);
+
+      await addEthChain({
+        chainId,
+        chainName: currentNet.name,
+        rpcUrls: [rpcUrl],
+        nativeCurrency: { name: "Canton", symbol: "CANTON", decimals: 18 },
+      });
+
+      const amountBigInt = parseTokenAmount(amount, selectedToken.decimals);
+      const data = encodeTransfer(recipient, amountBigInt);
+      const txHash = await sendEthTransaction({ from: address, to: selectedToken.address, data });
+
+      setReceipt({ txHash, token: selectedToken, amount, to: recipient });
+      setStep("done");
+    } catch (e: unknown) {
+      setError((e as Error).message);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function handleReset() {
+    setStep("details");
+    setAmount("");
+    setRecipient("");
+    setPrepared(null);
+    setSignPhase("idle");
+    setError(null);
+    setReceipt(null);
+  }
+
+  const pillClass = isNonCustodial ? styles.modePillNonCustodial : styles.modePillCustodial;
+  const pillLabel = isNonCustodial ? "NON-CUSTODIAL" : "CUSTODIAL";
+
+  return (
+    <>
+      <AmbientOrb opacity={0.1} size={880} x="80%" y="33%" />
+      <DashboardLayout
+        address={address}
+        network={network}
+        onNetworkChange={onNetworkChange}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        onDisconnect={onDisconnect}
+      >
+        {/* Header */}
+        <div className={styles.pageHeader}>
+          <h1 className={styles.pageTitle}>Transfer</h1>
+          <span className={cn(styles.modePill, pillClass)}>{pillLabel}</span>
+        </div>
+
+        <StepsBar step={step} />
+
+        {/* Error banner */}
+        {error && <div className={styles.errorBanner}>{error}</div>}
+
+        {/* ── Details step ── */}
+        {step === "details" && (
+          <>
+            <div className={styles.card}>
+              {/* Token selector */}
+              <div className={styles.fieldGroup}>
+                <p className={styles.fieldLabel}>TOKEN</p>
+                {tokensLoading ? (
+                  <Spinner />
+                ) : (
+                  <select
+                    className={styles.tokenSelect}
+                    value={selectedToken?.address ?? ""}
+                    onChange={(e) => {
+                      const t = tokens.find((tk) => tk.address === e.target.value) ?? null;
+                      setSelectedToken(t);
+                      setAmount("");
+                    }}
+                  >
+                    {tokens.map((t) => (
+                      <option key={t.address} value={t.address}>
+                        {t.symbol} — {t.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              {/* Recipient */}
+              <div className={styles.fieldGroup}>
+                <p className={styles.fieldLabel}>RECIPIENT</p>
+                <input
+                  className={styles.input}
+                  type="text"
+                  placeholder="0x..."
+                  value={recipient}
+                  onChange={(e) => setRecipient(e.target.value.trim())}
+                  spellCheck={false}
+                />
+              </div>
+
+              {/* Amount */}
+              <div className={styles.fieldGroup}>
+                <p className={styles.fieldLabel}>AMOUNT</p>
+                <div className={styles.amountRow}>
+                  <input
+                    className={styles.amountInput}
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0"
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                  />
+                  {balance !== null && selectedToken && (
+                    <button
+                      className={styles.maxBtn}
+                      onClick={() => setAmount(formatTokenAmount(balance, selectedToken.decimals))}
+                      type="button"
+                    >
+                      MAX
+                    </button>
+                  )}
+                </div>
+                {balance !== null && selectedToken && (
+                  <p className={styles.balanceHint}>
+                    Balance: {formatTokenAmount(balance, selectedToken.decimals)} {selectedToken.symbol}
+                  </p>
+                )}
+              </div>
+
+              {/* Info strip */}
+              <div className={styles.infoStrip}>
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <circle cx="7" cy="7" r="6" stroke="currentColor" strokeWidth="1.4" />
+                  <path d="M7 6V10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+                  <circle cx="7" cy="4" r="0.7" fill="currentColor" />
+                </svg>
+                {isNonCustodial
+                  ? "Gas-free on Canton · Settles in ~2–4s · You'll sign twice (MetaMask + Snap)"
+                  : "Gas-free on Canton · Settles in ~2–4s · One MetaMask confirmation"}
+              </div>
+            </div>
+
+            <div className={styles.actions}>
+              <button className={styles.btnContinue} onClick={handleContinue}>
+                Continue
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* ── Sign step (non-custodial) ── */}
+        {step === "sign" && isNonCustodial && (
+          <>
+            <div className={styles.signCard}>
+              <div className={cn(styles.signIcon, styles.signIconSnap)}>
+                {pending && signPhase !== "awaiting-snap" ? <Spinner /> : <SnapIcon />}
+              </div>
+
+              <p className={styles.signTitle}>Sign in Canton Snap</p>
+              <p className={styles.signSubtitle}>
+                {signPhase === "preparing"
+                  ? "Authenticating with MetaMask…"
+                  : "Review the transfer in your Canton Snap, then approve."}
+              </p>
+
+              {prepared && (
+                <div className={styles.hashPreview}>
+                  <span style={{ color: "var(--text-muted)", fontSize: 10, letterSpacing: 1 }}>TX HASH </span>
+                  {prepared.transactionHash}
+                </div>
+              )}
+
+              <button
+                className={styles.btnOpenDialog}
+                onClick={handleSnapSign}
+                disabled={pending || signPhase !== "awaiting-snap"}
+              >
+                {pending && signPhase === "signing" ? "Signing…" : "Open snap dialog"}
+              </button>
+
+              <div className={styles.signStatus}>
+                <div className={styles.statusRow}>
+                  <span
+                    className={cn(
+                      styles.statusDot,
+                      signPhase === "preparing" ? styles.statusDotActive : styles.statusDotDone,
+                    )}
+                  />
+                  <span className={signPhase !== "preparing" ? styles.statusDone : ""}>
+                    Authenticated with MetaMask
+                  </span>
+                </div>
+                <div className={styles.statusRow}>
+                  <span
+                    className={cn(
+                      styles.statusDot,
+                      signPhase === "preparing"
+                        ? styles.statusDotPending
+                        : signPhase === "awaiting-snap"
+                          ? styles.statusDotDone
+                          : styles.statusDotDone,
+                    )}
+                  />
+                  <span className={prepared ? styles.statusDone : ""}>Transaction prepared</span>
+                </div>
+                <div className={styles.statusRow}>
+                  <span
+                    className={cn(
+                      styles.statusDot,
+                      signPhase === "signing" || signPhase === "executing"
+                        ? styles.statusDotActive
+                        : styles.statusDotPending,
+                    )}
+                  />
+                  <span>Canton Snap signing</span>
+                </div>
+              </div>
+
+              <button className={styles.btnCancel} onClick={handleReset}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* ── Sign step (custodial) ── */}
+        {step === "sign" && !isNonCustodial && selectedToken && (
+          <>
+            <div className={styles.signCard}>
+              <div className={cn(styles.signIcon, styles.signIconMetaMask)}>
+                {pending ? <Spinner /> : <MetaMaskIcon />}
+              </div>
+
+              <p className={styles.signTitle}>Confirm in MetaMask</p>
+              <p className={styles.signSubtitle}>
+                Custodial mode — no Canton Snap required. The server co-signs the Canton side.
+              </p>
+
+              <div className={styles.contractPreview}>
+                <span className={styles.contractCall}>
+                  {selectedToken.symbol.toLowerCase()}.transfer(
+                  {shortenAddress(recipient)}, {parseTokenAmount(amount, selectedToken.decimals).toString()})
+                </span>
+                {" "}via /eth
+              </div>
+
+              <button
+                className={styles.btnOpenDialog}
+                onClick={handleMetaMaskSign}
+                disabled={pending}
+              >
+                {pending ? "Waiting for MetaMask…" : "Open MetaMask"}
+              </button>
+
+              <div className={styles.signStatus}>
+                <div className={styles.statusRow}>
+                  <span className={cn(styles.statusDot, pending ? styles.statusDotActive : styles.statusDotPending)} />
+                  <span>MetaMask confirmation</span>
+                </div>
+                <div className={styles.statusRow}>
+                  <span className={cn(styles.statusDot, styles.statusDotPending)} />
+                  <span>Server signs Canton side</span>
+                </div>
+              </div>
+
+              <button className={styles.btnCancel} onClick={handleReset}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* ── Done step ── */}
+        {step === "done" && receipt && (
+          <div className={styles.doneCard}>
+            <div className={styles.checkCircle}>
+              <CheckIcon />
+            </div>
+
+            <p className={styles.doneTitle}>Transfer sent</p>
+            <p className={styles.doneSubtitle}>Settled on Canton in under 4 seconds.</p>
+
+            <div className={styles.receipt}>
+              <div className={styles.receiptRow}>
+                <span className={styles.receiptLabel}>AMOUNT</span>
+                <span className={cn(styles.receiptValue, styles.receiptAmount)}>
+                  {receipt.amount} {receipt.token.symbol}
+                </span>
+              </div>
+              <div className={styles.receiptRow}>
+                <span className={styles.receiptLabel}>TO</span>
+                <span className={styles.receiptValue}>{receipt.to}</span>
+              </div>
+              <div className={styles.receiptRow}>
+                <span className={styles.receiptLabel}>TX HASH</span>
+                <span className={styles.receiptValue}>{receipt.txHash}</span>
+              </div>
+              <div className={styles.receiptRow}>
+                <span className={styles.receiptLabel}>COMPLETED</span>
+                <span className={styles.receiptValue}>Just now</span>
+              </div>
+            </div>
+
+            <div className={styles.doneActions}>
+              <button className={styles.btnSendAnother} onClick={handleReset}>
+                Send another
+              </button>
+            </div>
+          </div>
+        )}
+      </DashboardLayout>
+    </>
+  );
+}

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -296,6 +296,7 @@ export function TransferPage({
   // and must not cause re-runs mid-flight.
   useEffect(() => {
     if (step !== "sign" || !isNonCustodial || !selectedToken) return;
+    const token = selectedToken;
     let cancelled = false;
 
     async function prepare() {
@@ -307,7 +308,7 @@ export function TransferPage({
           currentNet.middlewareUrl,
           address,
           recipient,
-          selectedToken.symbol,
+          token.symbol,
           amount,
         );
         if (cancelled) return;

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -13,7 +13,12 @@ import {
   ethChainId,
 } from "../lib/ethrpc";
 import { prepareTransfer, executeTransfer, type PrepareResult } from "../lib/transfer";
-import { addEthChain, sendEthTransaction, shortenAddress, toChecksumAddress } from "../lib/ethereum";
+import {
+  addEthChain,
+  sendEthTransaction,
+  shortenAddress,
+  toChecksumAddress,
+} from "../lib/ethereum";
 import { TOKEN_COLORS } from "../lib/tokens";
 import { useSnap } from "../hooks/useSnap";
 import { cn } from "../lib/cn";
@@ -50,7 +55,13 @@ function TokenAvatar({ symbol }: { symbol: string }) {
 
 function ChevronDown() {
   return (
-    <svg width="10" height="6" viewBox="0 0 10 6" fill="none" className={styles.tokenDropdownChevron}>
+    <svg
+      width="10"
+      height="6"
+      viewBox="0 0 10 6"
+      fill="none"
+      className={styles.tokenDropdownChevron}
+    >
       <path d="M1 1L5 5L9 1" stroke="#a1a6c4" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   );
@@ -247,10 +258,12 @@ export function TransferPage({
   // Load token list then fetch all balances
   useEffect(() => {
     let cancelled = false;
-    setTokensLoading(true);
     const rpcUrl = `${currentNet.middlewareUrl}/eth`;
-    getTokens(currentNet.middlewareUrl)
-      .then(async (list) => {
+
+    async function load() {
+      setTokensLoading(true);
+      try {
+        const list = await getTokens(currentNet.middlewareUrl);
         if (cancelled) return;
         setTokens(list);
         if (list.length > 0) setSelectedToken(list[0]);
@@ -265,42 +278,48 @@ export function TransferPage({
           }),
         );
         if (!cancelled) setBalances(new Map(entries));
-      })
-      .catch(() => {})
-      .finally(() => { if (!cancelled) setTokensLoading(false); });
+      } catch {
+        // token list fetch failed — leave empty state
+      } finally {
+        if (!cancelled) setTokensLoading(false);
+      }
+    }
+
+    void load();
     return () => { cancelled = true; };
   }, [currentNet.middlewareUrl, address]);
 
-  // Auto-run prepare when entering sign step (non-custodial only)
+  // Auto-run prepare when entering sign step (non-custodial only).
+  // Depends only on [step]: fires once on entry; form fields are captured via closure
+  // and must not cause re-runs mid-flight.
   useEffect(() => {
     if (step !== "sign" || !isNonCustodial || !selectedToken) return;
     let cancelled = false;
-    setSignPhase("preparing");
-    setPending(true);
-    setError(null);
 
-    prepareTransfer(currentNet.middlewareUrl, address, recipient, selectedToken.symbol, amount)
-      .then((result) => {
+    async function prepare() {
+      setSignPhase("preparing");
+      setPending(true);
+      setError(null);
+      try {
+        const result = await prepareTransfer(
+          currentNet.middlewareUrl, address, recipient, selectedToken.symbol, amount,
+        );
         if (cancelled) return;
         setPrepared(result);
         setSignPhase("awaiting-snap");
-      })
-      .catch((e: unknown) => {
+      } catch (e: unknown) {
         if (cancelled) return;
         setError((e as Error).message);
         setStep("details");
         setSignPhase("idle");
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setPending(false);
-      });
+      }
+    }
 
-    return () => {
-      cancelled = true;
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  // Intentionally depends only on [step]: prepare should fire once on entry to the sign
-  // step, not re-run when form fields (recipient, amount, selectedToken) change mid-flight.
+    void prepare();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
 
   function validate(): string | null {
@@ -309,14 +328,18 @@ export function TransferPage({
     if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) return "Enter a positive amount";
     const bal = balances.get(selectedToken.address);
     if (bal !== undefined) {
-      if (parseTokenAmount(amount, selectedToken.decimals) > bal) return "Amount exceeds your balance";
+      if (parseTokenAmount(amount, selectedToken.decimals) > bal)
+        return "Amount exceeds your balance";
     }
     return null;
   }
 
   function handleContinue() {
     const err = validate();
-    if (err) { setError(err); return; }
+    if (err) {
+      setError(err);
+      return;
+    }
     setError(null);
     setStep("sign");
   }
@@ -481,9 +504,7 @@ export function TransferPage({
                   Paste
                 </button>
               </div>
-              {recipientValid && (
-                <p className={styles.recipientHint}>✓ Valid EVM address</p>
-              )}
+              {recipientValid && <p className={styles.recipientHint}>✓ Valid EVM address</p>}
             </div>
 
             {/* Amount */}
@@ -496,13 +517,19 @@ export function TransferPage({
                   inputMode="decimal"
                   placeholder="0"
                   value={amount}
-                  onChange={(e) => { setAmount(e.target.value); setError(null); }}
+                  onChange={(e) => {
+                    setAmount(e.target.value);
+                    setError(null);
+                  }}
                 />
                 {selectedBalance !== undefined && selectedToken && (
                   <button
                     className={styles.maxBtn}
                     type="button"
-                    onClick={() => { setAmount(formatTokenAmount(selectedBalance, selectedToken.decimals)); setError(null); }}
+                    onClick={() => {
+                      setAmount(formatTokenAmount(selectedBalance, selectedToken.decimals));
+                      setError(null);
+                    }}
                   >
                     MAX
                   </button>
@@ -530,13 +557,17 @@ export function TransferPage({
               ) : (
                 <span>
                   Gas-free on Canton · Settles in ~2–4s ·{" "}
-                  <strong style={{ color: "var(--text-primary)" }}>one MetaMask signature</strong>{" "}
-                  — server co-signs Canton side
+                  <strong style={{ color: "var(--text-primary)" }}>one MetaMask signature</strong> —
+                  server co-signs Canton side
                 </span>
               )}
             </div>
 
-            <button className={styles.btnContinue} onClick={handleContinue} disabled={tokensLoading}>
+            <button
+              className={styles.btnContinue}
+              onClick={handleContinue}
+              disabled={tokensLoading}
+            >
               Continue
             </button>
           </PageCard>
@@ -556,7 +587,13 @@ export function TransferPage({
                     strokeWidth="1.8"
                     strokeLinejoin="round"
                   />
-                  <path d="M9 14L12 17L19 11" stroke="#00d4a4" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                  <path
+                    d="M9 14L12 17L19 11"
+                    stroke="#00d4a4"
+                    strokeWidth="1.6"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
                 </svg>
               )}
             </div>
@@ -566,10 +603,10 @@ export function TransferPage({
               {signPhase === "preparing"
                 ? "Authenticating with MetaMask…"
                 : signPhase === "signing"
-                ? "Approve the request in the Canton Snap dialog…"
-                : signPhase === "executing"
-                ? "Submitting transaction to Canton…"
-                : "Review the transaction hash in the snap dialog and approve to send the transfer."}
+                  ? "Approve the request in the Canton Snap dialog…"
+                  : signPhase === "executing"
+                    ? "Submitting transaction to Canton…"
+                    : "Review the transaction hash in the snap dialog and approve to send the transfer."}
             </p>
 
             {prepared && (
@@ -587,8 +624,8 @@ export function TransferPage({
               {signPhase === "signing"
                 ? "Signing…"
                 : signPhase === "executing"
-                ? "Executing…"
-                : "Open snap dialog"}
+                  ? "Executing…"
+                  : "Open snap dialog"}
             </button>
 
             <div className={styles.signStatusRow}>
@@ -657,7 +694,11 @@ export function TransferPage({
               </span>
             </div>
 
-            <button className={styles.btnOpenDialog} onClick={handleMetaMaskSign} disabled={pending}>
+            <button
+              className={styles.btnOpenDialog}
+              onClick={handleMetaMaskSign}
+              disabled={pending}
+            >
               {pending ? "Waiting for MetaMask…" : "Open MetaMask"}
             </button>
 
@@ -721,10 +762,7 @@ export function TransferPage({
               <button className={styles.btnSendAnother} onClick={handleReset}>
                 Send another
               </button>
-              <button
-                className={styles.btnViewActivity}
-                onClick={() => onTabChange("balances")}
-              >
+              <button className={styles.btnViewActivity} onClick={() => onTabChange("balances")}>
                 View in Activity →
               </button>
             </div>

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -246,10 +246,12 @@ export function TransferPage({
 
   // Load token list then fetch all balances
   useEffect(() => {
+    let cancelled = false;
     setTokensLoading(true);
     const rpcUrl = `${currentNet.middlewareUrl}/eth`;
     getTokens(currentNet.middlewareUrl)
       .then(async (list) => {
+        if (cancelled) return;
         setTokens(list);
         if (list.length > 0) setSelectedToken(list[0]);
         const entries = await Promise.all(
@@ -262,10 +264,11 @@ export function TransferPage({
             }
           }),
         );
-        setBalances(new Map(entries));
+        if (!cancelled) setBalances(new Map(entries));
       })
       .catch(() => {})
-      .finally(() => setTokensLoading(false));
+      .finally(() => { if (!cancelled) setTokensLoading(false); });
+    return () => { cancelled = true; };
   }, [currentNet.middlewareUrl, address]);
 
   // Auto-run prepare when entering sign step (non-custodial only)
@@ -295,7 +298,10 @@ export function TransferPage({
     return () => {
       cancelled = true;
     };
-  }, [step]); // eslint-disable-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Intentionally depends only on [step]: prepare should fire once on entry to the sign
+  // step, not re-run when form fields (recipient, amount, selectedToken) change mid-flight.
+  }, [step]);
 
   function validate(): string | null {
     if (!selectedToken) return "Select a token";
@@ -317,6 +323,15 @@ export function TransferPage({
 
   async function handleSnapSign() {
     if (!prepared || !selectedToken) return;
+
+    if (new Date(prepared.expiresAt) <= new Date()) {
+      setError("Transfer preparation expired — please go back and try again.");
+      setPrepared(null);
+      setStep("details");
+      setSignPhase("idle");
+      return;
+    }
+
     setPending(true);
     setError(null);
     try {
@@ -443,6 +458,7 @@ export function TransferPage({
                   onSelect={(t) => {
                     setSelectedToken(t);
                     setAmount("");
+                    setError(null);
                   }}
                 />
               )}
@@ -466,7 +482,7 @@ export function TransferPage({
                 </button>
               </div>
               {recipientValid && (
-                <p className={styles.recipientHint}>✓ Registered Canton party</p>
+                <p className={styles.recipientHint}>✓ Valid EVM address</p>
               )}
             </div>
 
@@ -480,13 +496,13 @@ export function TransferPage({
                   inputMode="decimal"
                   placeholder="0"
                   value={amount}
-                  onChange={(e) => setAmount(e.target.value)}
+                  onChange={(e) => { setAmount(e.target.value); setError(null); }}
                 />
                 {selectedBalance !== undefined && selectedToken && (
                   <button
                     className={styles.maxBtn}
                     type="button"
-                    onClick={() => setAmount(formatTokenAmount(selectedBalance, selectedToken.decimals))}
+                    onClick={() => { setAmount(formatTokenAmount(selectedBalance, selectedToken.decimals)); setError(null); }}
                   >
                     MAX
                   </button>
@@ -520,7 +536,7 @@ export function TransferPage({
               )}
             </div>
 
-            <button className={styles.btnContinue} onClick={handleContinue}>
+            <button className={styles.btnContinue} onClick={handleContinue} disabled={tokensLoading}>
               Continue
             </button>
           </PageCard>
@@ -549,6 +565,10 @@ export function TransferPage({
             <p className={styles.signSubtitle}>
               {signPhase === "preparing"
                 ? "Authenticating with MetaMask…"
+                : signPhase === "signing"
+                ? "Approve the request in the Canton Snap dialog…"
+                : signPhase === "executing"
+                ? "Submitting transaction to Canton…"
                 : "Review the transaction hash in the snap dialog and approve to send the transfer."}
             </p>
 
@@ -564,7 +584,11 @@ export function TransferPage({
               onClick={handleSnapSign}
               disabled={pending || signPhase !== "awaiting-snap"}
             >
-              {pending && signPhase === "signing" ? "Signing…" : "Open snap dialog"}
+              {signPhase === "signing"
+                ? "Signing…"
+                : signPhase === "executing"
+                ? "Executing…"
+                : "Open snap dialog"}
             </button>
 
             <div className={styles.signStatusRow}>

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
+import { PageCard } from "../components/PageCard";
 import { Spinner } from "../components/Spinner";
 import { getNetwork, type NetworkId } from "../lib/config";
 import { getTokens, type TokenConfig } from "../lib/middleware";
@@ -12,7 +13,7 @@ import {
   ethChainId,
 } from "../lib/ethrpc";
 import { prepareTransfer, executeTransfer, type PrepareResult } from "../lib/transfer";
-import { addEthChain, sendEthTransaction, shortenAddress } from "../lib/ethereum";
+import { addEthChain, sendEthTransaction, shortenAddress, toChecksumAddress } from "../lib/ethereum";
 import { TOKEN_COLORS } from "../lib/tokens";
 import { useSnap } from "../hooks/useSnap";
 import { cn } from "../lib/cn";
@@ -388,10 +389,14 @@ export function TransferPage({
   async function handlePaste() {
     try {
       const text = await navigator.clipboard.readText();
-      setRecipient(text.trim());
+      setRecipient(toChecksumAddress(text.trim()));
     } catch {
       // clipboard access denied — no-op
     }
+  }
+
+  function handleRecipientBlur() {
+    if (recipient) setRecipient(toChecksumAddress(recipient));
   }
 
   const recipientValid = /^0x[0-9a-fA-F]{40}$/.test(recipient);
@@ -424,7 +429,7 @@ export function TransferPage({
 
         {/* ── Details step ── */}
         {step === "details" && (
-          <div className={styles.card}>
+          <PageCard className={styles.card}>
             {/* Token */}
             <div className={styles.fieldGroup}>
               <p className={styles.fieldLabel}>TOKEN</p>
@@ -453,6 +458,7 @@ export function TransferPage({
                   placeholder="0x..."
                   value={recipient}
                   onChange={(e) => setRecipient(e.target.value.trim())}
+                  onBlur={handleRecipientBlur}
                   spellCheck={false}
                 />
                 <button className={styles.pasteBtn} type="button" onClick={handlePaste}>
@@ -517,7 +523,7 @@ export function TransferPage({
             <button className={styles.btnContinue} onClick={handleContinue}>
               Continue
             </button>
-          </div>
+          </PageCard>
         )}
 
         {/* ── Sign step (non-custodial) ── */}
@@ -650,7 +656,7 @@ export function TransferPage({
 
         {/* ── Done step ── */}
         {step === "done" && receipt && (
-          <div className={styles.doneCard}>
+          <PageCard className={styles.doneCard}>
             <div className={styles.checkCircle}>
               <svg width="28" height="20" viewBox="0 0 28 20" fill="none">
                 <path
@@ -698,7 +704,7 @@ export function TransferPage({
                 View in Activity →
               </button>
             </div>
-          </div>
+          </PageCard>
         )}
       </DashboardLayout>
     </>

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -389,7 +389,9 @@ export function TransferPage({
       setStep("done");
     } catch (e: unknown) {
       setError((e as Error).message);
-      setSignPhase("awaiting-snap");
+      setPrepared(null);
+      setStep("details");
+      setSignPhase("idle");
     } finally {
       setPending(false);
     }
@@ -561,7 +563,8 @@ export function TransferPage({
               {isNonCustodial ? (
                 <span>
                   Gas-free on Canton · Settles in ~2–4s · You&apos;ll sign{" "}
-                  <strong style={{ color: "var(--text-primary)" }}>twice</strong> (MetaMask + Snap)
+                  <strong style={{ color: "var(--text-primary)" }}>three times</strong> (MetaMask
+                  auth × 2 + Snap)
                 </span>
               ) : (
                 <span>


### PR DESCRIPTION
Closes #16 
## Summary

- Implements the full **Transfer** tab for both custodial and non-custodial key modes
- Adds a shared `PageCard` component used by Transfer and Balances pages for visual consistency
- Fixes EIP-55 checksum address normalisation on paste/blur (uses `ethers.getAddress`)
- Fixes non-custodial signing: SHA-256 the Canton multihash before passing to `canton_signHash`, matching Go's `keys.SignDER` behaviour

## Test plan

- [ ] Connect wallet, register as external (non-custodial) user
- [ ] Navigate to Transfer tab, select token, enter registered recipient address, enter amount
- [ ] Confirm "Continue" is disabled while tokens load; validate error clearing on field change
- [ ] Complete non-custodial flow: MetaMask auth → Snap dialog → execute → Done receipt shown
- [ ] Complete custodial flow: MetaMask ERC-20 sign → Done receipt shown
- [ ] Paste a lowercase address — confirm it is checksummed on paste and on blur
- [ ] Enter an expired prepared transfer (wait or mock) — confirm reset to Details with error
- [ ] Click "Send →" on Balances tab — confirm navigation to Transfer with correct token pre-selected
