### PR TITLE
feat: activity tab with ERC-20 transfer history

### DIFF
--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -13,6 +13,7 @@ import { NonCustodialRegistrationPage } from "./pages/NonCustodialRegistrationPa
 import { RegistrationDonePage } from "./pages/RegistrationDonePage";
 import { DashboardProfilePage } from "./pages/DashboardProfilePage";
 import { DashboardBalancesPage } from "./pages/DashboardBalancesPage";
+import { DashboardActivityPage } from "./pages/DashboardActivityPage";
 import { TransferPage } from "./pages/TransferPage";
 import type { DashboardTab } from "./components/DashboardLayout";
 
@@ -320,6 +321,10 @@ export default function App() {
 
     if (dashboardTab === "transfer") {
       return <TransferPage {...sharedProps} keyMode={profile.keyMode} />;
+    }
+
+    if (dashboardTab === "activity") {
+      return <DashboardActivityPage {...sharedProps} />;
     }
 
     return (

--- a/packages/dapp/src/components/DashboardLayout.tsx
+++ b/packages/dapp/src/components/DashboardLayout.tsx
@@ -7,7 +7,7 @@ import { getNetwork, type NetworkId } from "../lib/config";
 import { cn } from "../lib/cn";
 import styles from "./DashboardLayout.module.css";
 
-export type DashboardTab = "profile" | "balances" | "transfer";
+export type DashboardTab = "profile" | "balances" | "transfer" | "activity";
 
 interface Props {
   address: string;
@@ -106,7 +106,7 @@ const NAV = [
   { id: "balances" as DashboardTab, label: "Balances", Icon: BalancesIcon },
   { id: "transfer" as DashboardTab, label: "Transfer", Icon: TransferIcon },
   { id: "bridge", label: "Bridge", Icon: BridgeIcon, disabled: true },
-  { id: "activity", label: "Activity", Icon: ActivityIcon, disabled: true },
+  { id: "activity" as DashboardTab, label: "Activity", Icon: ActivityIcon },
 ];
 
 export function DashboardLayout({
@@ -167,7 +167,13 @@ export function DashboardLayout({
                 disabled={isDisabled}
                 aria-current={isActive ? "page" : undefined}
                 onClick={() => {
-                  if (id === "profile" || id === "balances" || id === "transfer") onTabChange(id);
+                  if (
+                    id === "profile" ||
+                    id === "balances" ||
+                    id === "transfer" ||
+                    id === "activity"
+                  )
+                    onTabChange(id);
                 }}
               >
                 <Icon />

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -1,5 +1,12 @@
 let _rpcId = 0;
 
+const ERC20_TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+function padAddress(address: string): string {
+  return "0x000000000000000000000000" + address.replace(/^0x/i, "").toLowerCase();
+}
+
 function encodeBalanceOf(address: string): string {
   return "0x70a08231" + address.replace(/^0x/i, "").toLowerCase().padStart(64, "0");
 }
@@ -51,6 +58,143 @@ export async function ethChainId(rpcUrl: string): Promise<string> {
   const json = await res.json();
   if (json.error) throw new Error(json.error.message as string);
   return json.result as string;
+}
+
+interface RawLog {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  transactionHash: string;
+  logIndex: string;
+}
+
+export interface TransferLog {
+  txHash: string;
+  blockNumber: number;
+  timestamp: number;
+  direction: "sent" | "received";
+  tokenAddress: string;
+  amount: bigint;
+  from: string;
+  to: string;
+}
+
+async function ethGetLogs(rpcUrl: string, filter: unknown): Promise<RawLog[]> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_getLogs",
+      params: [filter],
+      id: ++_rpcId,
+    }),
+  });
+  const json = (await res.json()) as { result?: unknown; error?: { message: string } };
+  if (json.error) throw new Error(json.error.message);
+  return (json.result as RawLog[]) ?? [];
+}
+
+async function getBlockTimestamps(
+  rpcUrl: string,
+  blockNumbers: string[],
+): Promise<Map<string, number>> {
+  const unique = [...new Set(blockNumbers)];
+  const results = await Promise.all(
+    unique.map(async (bn) => {
+      const res = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "eth_getBlockByNumber",
+          params: [bn, false],
+          id: ++_rpcId,
+        }),
+      });
+      const json = (await res.json()) as { result?: { timestamp: string } };
+      const ts = json.result?.timestamp ? parseInt(json.result.timestamp, 16) : 0;
+      return [bn, ts] as [string, number];
+    }),
+  );
+  return new Map(results);
+}
+
+async function ethBlockNumber(rpcUrl: string): Promise<string> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_blockNumber",
+      params: [],
+      id: ++_rpcId,
+    }),
+  });
+  const json = (await res.json()) as { result?: string; error?: { message: string } };
+  if (json.error) throw new Error(json.error.message);
+  return json.result ?? "0x0";
+}
+
+export async function getTransferLogs(
+  rpcUrl: string,
+  tokenAddresses: string[],
+  userAddress: string,
+): Promise<TransferLog[]> {
+  const paddedUser = padAddress(userAddress);
+  const toBlock = await ethBlockNumber(rpcUrl);
+
+  const perToken = await Promise.all(
+    tokenAddresses.map(async (tokenAddr) => {
+      const [sentRaw, receivedRaw] = await Promise.all([
+        ethGetLogs(rpcUrl, {
+          fromBlock: "0x0",
+          toBlock,
+          address: tokenAddr,
+          topics: [ERC20_TRANSFER_TOPIC, paddedUser],
+        }),
+        ethGetLogs(rpcUrl, {
+          fromBlock: "0x0",
+          toBlock,
+          address: tokenAddr,
+          topics: [ERC20_TRANSFER_TOPIC, null, paddedUser],
+        }),
+      ]);
+
+      // self-transfers appear in both queries — keep them under "sent" only
+      const sentKeys = new Set(sentRaw.map((l) => `${l.transactionHash}-${l.logIndex}`));
+      const uniqueReceived = receivedRaw.filter(
+        (l) => !sentKeys.has(`${l.transactionHash}-${l.logIndex}`),
+      );
+
+      return [
+        ...sentRaw.map((l) => ({ ...l, direction: "sent" as const })),
+        ...uniqueReceived.map((l) => ({ ...l, direction: "received" as const })),
+      ];
+    }),
+  );
+
+  const flat = perToken.flat();
+  if (flat.length === 0) return [];
+
+  const timestamps = await getBlockTimestamps(
+    rpcUrl,
+    flat.map((l) => l.blockNumber),
+  );
+
+  return flat
+    .map((l) => ({
+      txHash: l.transactionHash,
+      blockNumber: parseInt(l.blockNumber, 16),
+      timestamp: timestamps.get(l.blockNumber) ?? 0,
+      direction: l.direction,
+      tokenAddress: l.address.toLowerCase(),
+      amount: BigInt(l.data),
+      from: "0x" + l.topics[1].slice(26),
+      to: "0x" + l.topics[2].slice(26),
+    }))
+    .sort((a, b) => b.blockNumber - a.blockNumber);
 }
 
 export function formatTokenAmount(raw: bigint, decimals: number): string {

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -1,7 +1,6 @@
 let _rpcId = 0;
 
-const ERC20_TRANSFER_TOPIC =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 function padAddress(address: string): string {
   return "0x000000000000000000000000" + address.replace(/^0x/i, "").toLowerCase();
@@ -65,6 +64,7 @@ interface RawLog {
   topics: string[];
   data: string;
   blockNumber: string;
+  blockTimestamp: string; // added by canton-middleware PR #241
   transactionHash: string;
   logIndex: string;
 }
@@ -94,31 +94,6 @@ async function ethGetLogs(rpcUrl: string, filter: unknown): Promise<RawLog[]> {
   const json = (await res.json()) as { result?: unknown; error?: { message: string } };
   if (json.error) throw new Error(json.error.message);
   return (json.result as RawLog[]) ?? [];
-}
-
-async function getBlockTimestamps(
-  rpcUrl: string,
-  blockNumbers: string[],
-): Promise<Map<string, number>> {
-  const unique = [...new Set(blockNumbers)];
-  const results = await Promise.all(
-    unique.map(async (bn) => {
-      const res = await fetch(rpcUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "eth_getBlockByNumber",
-          params: [bn, false],
-          id: ++_rpcId,
-        }),
-      });
-      const json = (await res.json()) as { result?: { timestamp: string } };
-      const ts = json.result?.timestamp ? parseInt(json.result.timestamp, 16) : 0;
-      return [bn, ts] as [string, number];
-    }),
-  );
-  return new Map(results);
 }
 
 async function ethBlockNumber(rpcUrl: string): Promise<string> {
@@ -175,22 +150,16 @@ export async function getTransferLogs(
     }),
   );
 
-  const flat = perToken.flat();
-  if (flat.length === 0) return [];
-
-  const timestamps = await getBlockTimestamps(
-    rpcUrl,
-    flat.map((l) => l.blockNumber),
-  );
-
-  return flat
+  return perToken
+    .flat()
+    .filter((l) => l.topics.length >= 3)
     .map((l) => ({
       txHash: l.transactionHash,
       blockNumber: parseInt(l.blockNumber, 16),
-      timestamp: timestamps.get(l.blockNumber) ?? 0,
+      timestamp: l.blockTimestamp ? parseInt(l.blockTimestamp, 16) : 0,
       direction: l.direction,
       tokenAddress: l.address.toLowerCase(),
-      amount: BigInt(l.data),
+      amount: l.data && l.data !== "0x" ? BigInt(l.data) : 0n,
       from: "0x" + l.topics[1].slice(26),
       to: "0x" + l.topics[2].slice(26),
     }))

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -72,6 +72,7 @@ interface RawLog {
 export interface TransferLog {
   txHash: string;
   blockNumber: number;
+  logIndex: number;
   timestamp: number;
   direction: "sent" | "received";
   tokenAddress: string;
@@ -117,45 +118,44 @@ export async function getTransferLogs(
   tokenAddresses: string[],
   userAddress: string,
 ): Promise<TransferLog[]> {
+  if (tokenAddresses.length === 0) return [];
+
   const paddedUser = padAddress(userAddress);
+  // TODO: replace fromBlock "0x0" with block-range pagination once chain history grows
   const toBlock = await ethBlockNumber(rpcUrl);
 
-  const perToken = await Promise.all(
-    tokenAddresses.map(async (tokenAddr) => {
-      const [sentRaw, receivedRaw] = await Promise.all([
-        ethGetLogs(rpcUrl, {
-          fromBlock: "0x0",
-          toBlock,
-          address: tokenAddr,
-          topics: [ERC20_TRANSFER_TOPIC, paddedUser],
-        }),
-        ethGetLogs(rpcUrl, {
-          fromBlock: "0x0",
-          toBlock,
-          address: tokenAddr,
-          topics: [ERC20_TRANSFER_TOPIC, null, paddedUser],
-        }),
-      ]);
-
-      // self-transfers appear in both queries — keep them under "sent" only
-      const sentKeys = new Set(sentRaw.map((l) => `${l.transactionHash}-${l.logIndex}`));
-      const uniqueReceived = receivedRaw.filter(
-        (l) => !sentKeys.has(`${l.transactionHash}-${l.logIndex}`),
-      );
-
-      return [
-        ...sentRaw.map((l) => ({ ...l, direction: "sent" as const })),
-        ...uniqueReceived.map((l) => ({ ...l, direction: "received" as const })),
-      ];
+  const [sentRaw, receivedRaw] = await Promise.all([
+    ethGetLogs(rpcUrl, {
+      fromBlock: "0x0",
+      toBlock,
+      address: tokenAddresses,
+      topics: [ERC20_TRANSFER_TOPIC, paddedUser],
     }),
+    ethGetLogs(rpcUrl, {
+      fromBlock: "0x0",
+      toBlock,
+      address: tokenAddresses,
+      topics: [ERC20_TRANSFER_TOPIC, null, paddedUser],
+    }),
+  ]);
+
+  // self-transfers appear in both queries — keep them under "sent" only
+  const sentKeys = new Set(sentRaw.map((l) => `${l.transactionHash}-${l.logIndex}`));
+  const uniqueReceived = receivedRaw.filter(
+    (l) => !sentKeys.has(`${l.transactionHash}-${l.logIndex}`),
   );
 
-  return perToken
-    .flat()
+  const allLogs = [
+    ...sentRaw.map((l) => ({ ...l, direction: "sent" as const })),
+    ...uniqueReceived.map((l) => ({ ...l, direction: "received" as const })),
+  ];
+
+  return allLogs
     .filter((l) => l.topics.length >= 3)
     .map((l) => ({
       txHash: l.transactionHash,
       blockNumber: parseInt(l.blockNumber, 16),
+      logIndex: parseInt(l.logIndex, 16),
       timestamp: l.blockTimestamp ? parseInt(l.blockTimestamp, 16) : 0,
       direction: l.direction,
       tokenAddress: l.address.toLowerCase(),
@@ -163,7 +163,7 @@ export async function getTransferLogs(
       from: "0x" + l.topics[1].slice(26),
       to: "0x" + l.topics[2].slice(26),
     }))
-    .sort((a, b) => b.blockNumber - a.blockNumber);
+    .sort((a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex);
 }
 
 export function formatTokenAmount(raw: bigint, decimals: number): string {

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -1,0 +1,365 @@
+/* ── Page header ── */
+.pageHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.pageTitles {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pageTitle {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+  color: var(--text-primary);
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* ── Search ── */
+.searchBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 296px;
+  height: 36px;
+  background: #12141f;
+  border: 1px solid var(--border-muted);
+  border-radius: 10px;
+  padding: 0 14px;
+  color: var(--text-muted);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.searchInput {
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: var(--font-sans);
+  width: 100%;
+}
+
+.searchInput::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── Filter tabs ── */
+.filters {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.filterTabs {
+  display: flex;
+  gap: 8px;
+}
+
+.filterTab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #12141f;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.filterTab:hover:not(.filterTabActive) {
+  background: #1a1d2e;
+  color: var(--text-primary);
+}
+
+.filterTabActive {
+  background: #1a1d2e;
+  border-color: var(--border-muted);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.filterTabCount {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 5px;
+  background: #232640;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* ── Column headers (above card) ── */
+.colHeaders {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  column-gap: 32px;
+  padding: 0 24px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.colRight {
+  text-align: right;
+}
+
+/* ── Activity card (full-width) ── */
+.card {
+  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+/* ── Day group label ── */
+.dayGroup {
+  padding: 16px 24px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+/* ── Activity row ── */
+.rowDivider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 24px;
+}
+
+.activityRow {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  column-gap: 32px;
+  align-items: center;
+  padding: 16px 24px;
+}
+
+/* Type cell */
+.typeCell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.typeIcon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.iconSent {
+  background: rgba(0, 212, 164, 0.12);
+  color: #00d4a4;
+}
+
+.iconReceived {
+  background: rgba(96, 165, 250, 0.14);
+  color: #60a5fa;
+}
+
+.typeLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* Token cell */
+.tokenCell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tokenIcon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.tokenSymbol {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* Address / tx cells */
+.addrCell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.addrLabel {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.addrRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.addrValue {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+
+/* Amount cell */
+.amountCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+}
+
+.amountValue {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.amountNeutral {
+  color: var(--text-primary);
+}
+
+.amountSent {
+  color: var(--text-primary);
+}
+
+.amountReceived {
+  color: #34d399;
+}
+
+.amountLabel {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Status cell */
+.statusCell {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.statusBadge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.statusSettled {
+  background: rgba(52, 211, 153, 0.15);
+  color: #34d399;
+}
+
+.statusSettled .statusDot {
+  background: #34d399;
+}
+
+/* When cell */
+.whenCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+
+.whenRelative {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.whenAbsolute {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Loading / error / empty */
+.centred {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.errorText {
+  font-size: 13px;
+  color: var(--amber);
+  text-align: center;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* ── Footer ── */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-top: 1px solid var(--border);
+}
+
+.footerCount {
+  font-size: 12px;
+  color: var(--text-muted);
+}

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -54,6 +54,15 @@
   color: var(--text-muted);
 }
 
+.searchBarDisabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.searchBarDisabled .searchInput {
+  cursor: not-allowed;
+}
+
 /* ── Filter tabs ── */
 .filters {
   display: flex;
@@ -262,10 +271,6 @@
   font-weight: 700;
 }
 
-.amountNeutral {
-  color: var(--text-primary);
-}
-
 .amountSent {
   color: var(--text-primary);
 }
@@ -277,39 +282,6 @@
 .amountLabel {
   font-size: 11px;
   color: var(--text-muted);
-}
-
-/* Status cell */
-.statusCell {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.statusBadge {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  height: 22px;
-  padding: 0 10px;
-  border-radius: 6px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.statusDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.statusSettled {
-  background: rgba(52, 211, 153, 0.15);
-  color: #34d399;
-}
-
-.statusSettled .statusDot {
-  background: #34d399;
 }
 
 /* When cell */

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -172,22 +172,18 @@ export function DashboardActivityPage({
     };
   }, [currentNet.middlewareUrl, address]);
 
-  const allRows = fetchState?.rows ?? [];
-
   const filtered = useMemo(() => {
-    let rows = allRows;
+    const rows = fetchState?.rows ?? [];
     const q = search.trim().toLowerCase();
-    if (q) {
-      rows = rows.filter(
-        (r) =>
-          r.txHash.toLowerCase().includes(q) ||
-          r.from.toLowerCase().includes(q) ||
-          r.to.toLowerCase().includes(q) ||
-          r.token.symbol.toLowerCase().includes(q),
-      );
-    }
-    return rows;
-  }, [allRows, search, filterTab]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!q) return rows;
+    return rows.filter(
+      (r) =>
+        r.txHash.toLowerCase().includes(q) ||
+        r.from.toLowerCase().includes(q) ||
+        r.to.toLowerCase().includes(q) ||
+        r.token.symbol.toLowerCase().includes(q),
+    );
+  }, [fetchState, search]);
 
   // Group rows by calendar day
   const groups = useMemo(() => {
@@ -220,13 +216,16 @@ export function DashboardActivityPage({
               Token transfers and bridge events for this wallet.
             </p>
           </div>
-          <label className={styles.searchBar}>
+          <label
+            className={`${styles.searchBar} ${filterTab === "bridge" ? styles.searchBarDisabled : ""}`}
+          >
             <SearchIcon />
             <input
               className={styles.searchInput}
               placeholder="Search by tx hash, address, or token…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              disabled={filterTab === "bridge"}
             />
           </label>
         </div>
@@ -267,7 +266,7 @@ export function DashboardActivityPage({
             </div>
           )}
 
-          {!loading && fetchState?.error && (
+          {!loading && filterTab === "transfers" && fetchState?.error && (
             <div className={styles.centred}>
               <p className={styles.errorText}>{fetchState.error}</p>
             </div>
@@ -281,7 +280,11 @@ export function DashboardActivityPage({
 
           {!loading && filterTab === "transfers" && fetchState?.rows && filtered.length === 0 && (
             <div className={styles.centred}>
-              <p className={styles.hint}>No transfers found for this address.</p>
+              <p className={styles.hint}>
+                {search.trim()
+                  ? "No transfers match your search."
+                  : "No transfers found for this address."}
+              </p>
             </div>
           )}
 
@@ -349,18 +352,12 @@ export function DashboardActivityPage({
 
                         {/* Date */}
                         <div className={styles.whenCell}>
-                          {row.timestamp >= MIN_REAL_TIMESTAMP ? (
-                            <>
-                              <span className={styles.whenRelative}>
-                                {relativeTime(row.timestamp)}
-                              </span>
-                              <span className={styles.whenAbsolute}>{timeUTC(row.timestamp)}</span>
-                            </>
-                          ) : (
-                            <span className={styles.whenAbsolute}>
-                              Block #{row.blockNumber}
-                            </span>
-                          )}
+                          <span className={styles.whenRelative}>{relativeTime(row.timestamp)}</span>
+                          <span className={styles.whenAbsolute}>
+                            {row.timestamp >= MIN_REAL_TIMESTAMP
+                              ? timeUTC(row.timestamp)
+                              : `Block #${row.blockNumber}`}
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -301,7 +301,7 @@ export function DashboardActivityPage({
                   const shortTx = `${row.txHash.slice(0, 10)}…${row.txHash.slice(-8)}`;
 
                   return (
-                    <div key={`${row.txHash}-${row.direction}`}>
+                    <div key={`${row.txHash}-${row.logIndex}`}>
                       {i > 0 && <div className={styles.rowDivider} />}
                       <div className={styles.activityRow}>
                         {/* Type */}

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -1,0 +1,383 @@
+import { useState, useEffect, useMemo } from "react";
+import { AmbientOrb } from "../components/AmbientOrb";
+import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
+import { Spinner } from "../components/Spinner";
+import { getNetwork, type NetworkId } from "../lib/config";
+import { getTokens, type TokenConfig } from "../lib/middleware";
+import { getTransferLogs, formatTokenAmount, type TransferLog } from "../lib/ethrpc";
+import { TOKEN_COLORS } from "../lib/tokens";
+import { toChecksumAddress, shortenAddress } from "../lib/ethereum";
+import { CopyButton } from "../components/CopyButton";
+import styles from "./DashboardActivityPage.module.css";
+
+interface Props {
+  address: string;
+  network: NetworkId;
+  onNetworkChange: (id: NetworkId) => void;
+  activeTab: DashboardTab;
+  onTabChange: (tab: DashboardTab) => void;
+  onDisconnect: () => void;
+}
+
+interface ActivityRow extends TransferLog {
+  token: TokenConfig;
+}
+
+type FilterTab = "transfers" | "bridge";
+
+type FetchState =
+  | { url: string; address: string; rows: ActivityRow[]; error: null }
+  | { url: string; address: string; rows: null; error: string };
+
+// Jan 1 2020 in Unix seconds — anything before this is a synthetic/bogus timestamp
+const MIN_REAL_TIMESTAMP = 1577836800;
+
+function relativeTime(ts: number): string {
+  if (!ts || ts < MIN_REAL_TIMESTAMP) return "—";
+  const diff = Date.now() / 1000 - ts;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 172800) return "Yesterday";
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function timeUTC(ts: number): string {
+  if (!ts || ts < MIN_REAL_TIMESTAMP) return "";
+  return new Date(ts * 1000).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+}
+
+function dayKey(ts: number): string {
+  if (!ts) return "unknown";
+  return new Date(ts * 1000).toDateString();
+}
+
+function dayLabel(ts: number): string {
+  if (!ts) return "UNKNOWN";
+  const d = new Date(ts * 1000);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const month = d.toLocaleDateString("en-US", { month: "short", day: "numeric" }).toUpperCase();
+  if (d.toDateString() === today.toDateString()) return `TODAY · ${month}`;
+  if (d.toDateString() === yesterday.toDateString()) return `YESTERDAY · ${month}`;
+  return d
+    .toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
+    .toUpperCase();
+}
+
+function ArrowUpIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M10 15V5M5 10L10 5L15 10"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+      <path
+        d="M10 5V15M5 10L10 15L15 10"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function TokenIcon({ symbol }: { symbol: string }) {
+  const colors = TOKEN_COLORS[symbol.toUpperCase()] ?? { bg: "#656a8a", text: "#ffffff" };
+  return (
+    <div className={styles.tokenIcon} style={{ background: colors.bg, color: colors.text }}>
+      {symbol.charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9.5 9.5L12 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function DashboardActivityPage({
+  address,
+  network,
+  onNetworkChange,
+  activeTab,
+  onTabChange,
+  onDisconnect,
+}: Props) {
+  const [fetchState, setFetchState] = useState<FetchState | null>(null);
+  const [filterTab, setFilterTab] = useState<FilterTab>("transfers");
+  const [search, setSearch] = useState("");
+
+  const currentNet = getNetwork(network);
+  const loading = fetchState?.url !== currentNet.middlewareUrl || fetchState?.address !== address;
+
+  useEffect(() => {
+    let cancelled = false;
+    const rpcUrl = `${currentNet.middlewareUrl}/eth`;
+
+    async function load() {
+      try {
+        const tokens = await getTokens(currentNet.middlewareUrl);
+        const tokenByAddress = new Map(tokens.map((t) => [t.address.toLowerCase(), t]));
+        const logs = await getTransferLogs(
+          rpcUrl,
+          tokens.map((t) => t.address),
+          address,
+        );
+        const rows: ActivityRow[] = logs
+          .map((log) => {
+            const token = tokenByAddress.get(log.tokenAddress);
+            if (!token) return null;
+            return { ...log, token };
+          })
+          .filter((r): r is ActivityRow => r !== null);
+
+        if (!cancelled)
+          setFetchState({ url: currentNet.middlewareUrl, address, rows, error: null });
+      } catch (e: unknown) {
+        if (!cancelled)
+          setFetchState({
+            url: currentNet.middlewareUrl,
+            address,
+            rows: null,
+            error: (e as Error).message,
+          });
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentNet.middlewareUrl, address]);
+
+  const allRows = fetchState?.rows ?? [];
+
+  const filtered = useMemo(() => {
+    let rows = allRows;
+    const q = search.trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (r) =>
+          r.txHash.toLowerCase().includes(q) ||
+          r.from.toLowerCase().includes(q) ||
+          r.to.toLowerCase().includes(q) ||
+          r.token.symbol.toLowerCase().includes(q),
+      );
+    }
+    return rows;
+  }, [allRows, search, filterTab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Group rows by calendar day
+  const groups = useMemo(() => {
+    const map = new Map<string, ActivityRow[]>();
+    for (const row of filtered) {
+      const key = dayKey(row.timestamp);
+      const arr = map.get(key) ?? [];
+      arr.push(row);
+      map.set(key, arr);
+    }
+    return [...map.entries()].map(([key, rows]) => ({ key, rows }));
+  }, [filtered]);
+
+  return (
+    <>
+      <AmbientOrb opacity={0.1} size={880} x="80%" y="33%" />
+      <DashboardLayout
+        address={address}
+        network={network}
+        onNetworkChange={onNetworkChange}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        onDisconnect={onDisconnect}
+      >
+        {/* Header */}
+        <div className={styles.pageHeader}>
+          <div className={styles.pageTitles}>
+            <h1 className={styles.pageTitle}>Activity</h1>
+            <p className={styles.pageSubtitle}>
+              Token transfers and bridge events for this wallet.
+            </p>
+          </div>
+          <label className={styles.searchBar}>
+            <SearchIcon />
+            <input
+              className={styles.searchInput}
+              placeholder="Search by tx hash, address, or token…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </label>
+        </div>
+
+        {/* Filter tabs */}
+        <div className={styles.filters}>
+          <div className={styles.filterTabs}>
+            {(["transfers", "bridge"] as FilterTab[]).map((tab) => (
+              <button
+                key={tab}
+                className={`${styles.filterTab} ${filterTab === tab ? styles.filterTabActive : ""}`}
+                onClick={() => setFilterTab(tab)}
+              >
+                {tab === "transfers" ? "Transfers" : "Bridge"}
+                {!loading && fetchState?.rows && tab === "transfers" && (
+                  <span className={styles.filterTabCount}>{filtered.length}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Column headers */}
+        <div className={styles.colHeaders}>
+          <span>TYPE</span>
+          <span>TOKEN</span>
+          <span>AMOUNT</span>
+          <span>TO / FROM</span>
+          <span>TX HASH</span>
+          <span className={styles.colRight}>DATE</span>
+        </div>
+
+        {/* Card */}
+        <div className={styles.card}>
+          {loading && (
+            <div className={styles.centred}>
+              <Spinner />
+            </div>
+          )}
+
+          {!loading && fetchState?.error && (
+            <div className={styles.centred}>
+              <p className={styles.errorText}>{fetchState.error}</p>
+            </div>
+          )}
+
+          {!loading && filterTab === "bridge" && (
+            <div className={styles.centred}>
+              <p className={styles.hint}>Bridge activity coming soon.</p>
+            </div>
+          )}
+
+          {!loading && filterTab === "transfers" && fetchState?.rows && filtered.length === 0 && (
+            <div className={styles.centred}>
+              <p className={styles.hint}>No transfers found for this address.</p>
+            </div>
+          )}
+
+          {!loading &&
+            filterTab === "transfers" &&
+            fetchState?.rows &&
+            filtered.length > 0 &&
+            groups.map(({ key, rows }) => (
+              <div key={key}>
+                <div className={styles.dayGroup}>{dayLabel(rows[0].timestamp)}</div>
+                {rows.map((row, i) => {
+                  const isSent = row.direction === "sent";
+                  const counterparty = toChecksumAddress(isSent ? row.to : row.from);
+                  const shortTx = `${row.txHash.slice(0, 10)}…${row.txHash.slice(-8)}`;
+
+                  return (
+                    <div key={`${row.txHash}-${row.direction}`}>
+                      {i > 0 && <div className={styles.rowDivider} />}
+                      <div className={styles.activityRow}>
+                        {/* Type */}
+                        <div className={styles.typeCell}>
+                          <div
+                            className={`${styles.typeIcon} ${isSent ? styles.iconSent : styles.iconReceived}`}
+                          >
+                            {isSent ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                          </div>
+                          <span className={styles.typeLabel}>{isSent ? "Sent" : "Received"}</span>
+                        </div>
+
+                        {/* Token */}
+                        <div className={styles.tokenCell}>
+                          <TokenIcon symbol={row.token.symbol} />
+                          <span className={styles.tokenSymbol}>{row.token.symbol}</span>
+                        </div>
+
+                        {/* Amount */}
+                        <div className={styles.amountCell}>
+                          <span
+                            className={`${styles.amountValue} ${isSent ? styles.amountSent : styles.amountReceived}`}
+                          >
+                            {isSent ? "−" : "+"}
+                            {formatTokenAmount(row.amount, row.token.decimals)}
+                          </span>
+                        </div>
+
+                        {/* To / From */}
+                        <div className={styles.addrCell}>
+                          <span className={styles.addrLabel}>{isSent ? "To" : "From"}</span>
+                          <div className={styles.addrRow}>
+                            <span className={styles.addrValue}>
+                              {shortenAddress(counterparty, 5)}
+                            </span>
+                            <CopyButton text={counterparty} />
+                          </div>
+                        </div>
+
+                        {/* Tx hash */}
+                        <div className={styles.addrCell}>
+                          <span className={styles.addrLabel}>Tx</span>
+                          <div className={styles.addrRow}>
+                            <span className={styles.addrValue}>{shortTx}</span>
+                            <CopyButton text={row.txHash} />
+                          </div>
+                        </div>
+
+                        {/* Date */}
+                        <div className={styles.whenCell}>
+                          {row.timestamp >= MIN_REAL_TIMESTAMP ? (
+                            <>
+                              <span className={styles.whenRelative}>
+                                {relativeTime(row.timestamp)}
+                              </span>
+                              <span className={styles.whenAbsolute}>{timeUTC(row.timestamp)}</span>
+                            </>
+                          ) : (
+                            <span className={styles.whenAbsolute}>
+                              Block #{row.blockNumber}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+
+          {!loading && filterTab === "transfers" && fetchState?.rows && filtered.length > 0 && (
+            <div className={styles.footer}>
+              <span className={styles.footerCount}>
+                Showing {filtered.length} transfer{filtered.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+          )}
+        </div>
+      </DashboardLayout>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds an **Activity** dashboard tab showing on-chain token transfer history for the connected wallet
- Queries `eth_getLogs` for ERC-20 `Transfer` events (sent + received) across all configured tokens via the middleware's `/eth` JSON-RPC endpoint
- Full-width table with six columns: **Type** | **Token** | **Amount** | **To/From** | **Tx Hash** | **Date**
- Filter tabs: **Transfers** (live data) and **Bridge** (empty state — pending middleware support)
- Client-side search by tx hash, address, or token symbol
- Day-group separators in the list
- Reuses the shared `CopyButton` component for one-click copy on addresses and tx hashes


## Test plan

- [ ] Activity tab appears in sidebar and is clickable
- [ ] Transfers tab shows ERC-20 transfer rows after completing a transfer
- [ ] Sent rows show teal up-arrow icon; received rows show blue down-arrow
- [ ] Copy button on To/From and Tx Hash copies the full value
- [ ] Search filters rows in real time
- [ ] Bridge tab shows empty state
- [ ] Date column shows "Block #N" (until middleware timestamp bug is fixed)