### PR TITLE
fix: ui bug fixes and improvements

### DIFF
--- a/packages/dapp/src/hooks/useRegistration.ts
+++ b/packages/dapp/src/hooks/useRegistration.ts
@@ -115,9 +115,8 @@ export function useRegistration(middlewareUrl: string): UseRegistrationReturn {
 function parseRegistered(details: string): RegistrationResult | null {
   try {
     const p = JSON.parse(details);
-    const partyId = p.party ?? p.canton_party_id;
-    if (partyId) {
-      return { cantonPartyId: partyId as string, fingerprint: (p.fingerprint as string) ?? "" };
+    if (p.canton_party_id) {
+      return { cantonPartyId: p.canton_party_id, fingerprint: p.fingerprint ?? "" };
     }
   } catch {
     // not JSON

--- a/packages/dapp/src/hooks/useRegistration.ts
+++ b/packages/dapp/src/hooks/useRegistration.ts
@@ -115,8 +115,9 @@ export function useRegistration(middlewareUrl: string): UseRegistrationReturn {
 function parseRegistered(details: string): RegistrationResult | null {
   try {
     const p = JSON.parse(details);
-    if (p.canton_party_id) {
-      return { cantonPartyId: p.canton_party_id, fingerprint: p.fingerprint ?? "" };
+    const partyId = p.party ?? p.canton_party_id;
+    if (partyId) {
+      return { cantonPartyId: partyId as string, fingerprint: (p.fingerprint as string) ?? "" };
     }
   } catch {
     // not JSON

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -2,7 +2,6 @@ let _rpcId = 0;
 
 const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
-
 function encodeBalanceOf(address: string): string {
   return "0x70a08231" + address.replace(/^0x/i, "").toLowerCase().padStart(64, "0");
 }

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -2,9 +2,6 @@ let _rpcId = 0;
 
 const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
-function padAddress(address: string): string {
-  return "0x000000000000000000000000" + address.replace(/^0x/i, "").toLowerCase();
-}
 
 function encodeBalanceOf(address: string): string {
   return "0x70a08231" + address.replace(/^0x/i, "").toLowerCase().padStart(64, "0");

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -102,22 +102,6 @@ async function ethGetLogs(rpcUrl: string, filter: unknown): Promise<RawLog[]> {
   return (json.result as RawLog[]) ?? [];
 }
 
-async function ethBlockNumber(rpcUrl: string): Promise<string> {
-  const res = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      method: "eth_blockNumber",
-      params: [],
-      id: ++_rpcId,
-    }),
-  });
-  const json = (await res.json()) as { result?: string; error?: { message: string } };
-  if (json.error) throw new Error(json.error.message);
-  return json.result ?? "0x0";
-}
-
 export async function getTransferLogs(
   rpcUrl: string,
   tokenAddresses: string[],
@@ -126,19 +110,17 @@ export async function getTransferLogs(
   if (tokenAddresses.length === 0) return [];
 
   const paddedUser = padAddress(userAddress);
-  // TODO: replace fromBlock "0x0" with block-range pagination once chain history grows
-  const toBlock = await ethBlockNumber(rpcUrl);
 
   const [sentRaw, receivedRaw] = await Promise.all([
     ethGetLogs(rpcUrl, {
-      fromBlock: "0x0",
-      toBlock,
+      fromBlock: "earliest",
+      toBlock: "latest",
       address: tokenAddresses,
       topics: [ERC20_TRANSFER_TOPIC, paddedUser],
     }),
     ethGetLogs(rpcUrl, {
-      fromBlock: "0x0",
-      toBlock,
+      fromBlock: "earliest",
+      toBlock: "latest",
       address: tokenAddresses,
       topics: [ERC20_TRANSFER_TOPIC, null, paddedUser],
     }),

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -109,48 +109,41 @@ export async function getTransferLogs(
 ): Promise<TransferLog[]> {
   if (tokenAddresses.length === 0) return [];
 
-  const paddedUser = padAddress(userAddress);
+  const userAddrLower = userAddress.toLowerCase();
 
-  const [sentRaw, receivedRaw] = await Promise.all([
-    ethGetLogs(rpcUrl, {
-      fromBlock: "earliest",
-      toBlock: "latest",
-      address: tokenAddresses,
-      topics: [ERC20_TRANSFER_TOPIC, paddedUser],
-    }),
-    ethGetLogs(rpcUrl, {
-      fromBlock: "earliest",
-      toBlock: "latest",
-      address: tokenAddresses,
-      topics: [ERC20_TRANSFER_TOPIC, null, paddedUser],
-    }),
-  ]);
-
-  // self-transfers appear in both queries — keep them under "sent" only
-  const sentKeys = new Set(sentRaw.map((l) => `${l.transactionHash}-${l.logIndex}`));
-  const uniqueReceived = receivedRaw.filter(
-    (l) => !sentKeys.has(`${l.transactionHash}-${l.logIndex}`),
+  // Query one address at a time: the middleware address filter only accepts a
+  // single string. fromBlock/toBlock are omitted so the middleware defaults to
+  // the full range (0 → latest). topic1/topic2 filtering is not supported
+  // server-side, so sent/received direction is determined client-side.
+  const perToken = await Promise.all(
+    tokenAddresses.map((addr) =>
+      ethGetLogs(rpcUrl, {
+        address: addr,
+        topics: [ERC20_TRANSFER_TOPIC],
+      }),
+    ),
   );
 
-  const allLogs = [
-    ...sentRaw.map((l) => ({ ...l, direction: "sent" as const })),
-    ...uniqueReceived.map((l) => ({ ...l, direction: "received" as const })),
-  ];
+  const logs: TransferLog[] = [];
+  for (const raw of perToken.flat()) {
+    if (raw.topics.length < 3) continue;
+    const from = ("0x" + raw.topics[1].slice(26)).toLowerCase();
+    const to = ("0x" + raw.topics[2].slice(26)).toLowerCase();
+    if (from !== userAddrLower && to !== userAddrLower) continue;
+    logs.push({
+      txHash: raw.transactionHash,
+      blockNumber: parseInt(raw.blockNumber, 16),
+      logIndex: parseInt(raw.logIndex, 16),
+      timestamp: raw.blockTimestamp ? parseInt(raw.blockTimestamp, 16) : 0,
+      direction: from === userAddrLower ? "sent" : "received",
+      tokenAddress: raw.address.toLowerCase(),
+      amount: raw.data && raw.data !== "0x" ? BigInt(raw.data) : 0n,
+      from,
+      to,
+    });
+  }
 
-  return allLogs
-    .filter((l) => l.topics.length >= 3)
-    .map((l) => ({
-      txHash: l.transactionHash,
-      blockNumber: parseInt(l.blockNumber, 16),
-      logIndex: parseInt(l.logIndex, 16),
-      timestamp: l.blockTimestamp ? parseInt(l.blockTimestamp, 16) : 0,
-      direction: l.direction,
-      tokenAddress: l.address.toLowerCase(),
-      amount: l.data && l.data !== "0x" ? BigInt(l.data) : 0n,
-      from: "0x" + l.topics[1].slice(26),
-      to: "0x" + l.topics[2].slice(26),
-    }))
-    .sort((a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex);
+  return logs.sort((a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex);
 }
 
 export function formatTokenAmount(raw: bigint, decimals: number): string {

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -68,7 +68,7 @@ export async function getUser(
   signature: string,
   message: string,
 ): Promise<UserProfile | null> {
-  const res = await fetch(`${baseUrl}/user?address=${encodeURIComponent(address)}`, {
+  const res = await fetch(`${baseUrl}/profile?address=${encodeURIComponent(address)}`, {
     headers: { "X-Signature": signature, "X-Message": message },
   });
   if (res.status === 404) return null;

--- a/packages/dapp/src/pages/DashboardBalancesPage.module.css
+++ b/packages/dapp/src/pages/DashboardBalancesPage.module.css
@@ -32,9 +32,18 @@
   font-size: 13px;
   font-weight: 700;
   font-family: var(--font-sans);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.sendBtn:hover {
+  opacity: 0.85;
+}
+
+.sendBtn:disabled {
   cursor: not-allowed;
   opacity: 0.55;
-  flex-shrink: 0;
 }
 
 /* ── Token card ── */

--- a/packages/dapp/src/pages/DashboardBalancesPage.tsx
+++ b/packages/dapp/src/pages/DashboardBalancesPage.tsx
@@ -98,7 +98,7 @@ export function DashboardBalancesPage({
             <h1 className={styles.pageTitle}>Balances</h1>
             <p className={styles.pageSubtitle}>Canton Network tokens held by this party.</p>
           </div>
-          <button className={styles.sendBtn} disabled>
+          <button className={styles.sendBtn} onClick={() => onTabChange("transfer")}>
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
               <path
                 d="M3 8H13M9 4L13 8L9 12"

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -86,12 +86,21 @@
   padding: 16px 20px;
   border-radius: var(--radius-md);
   border: none;
-  cursor: not-allowed;
+  cursor: pointer;
   font-family: var(--font-sans);
-  opacity: 0.6;
   margin-top: 12px;
   width: 100%;
   text-align: left;
+  transition: opacity 0.15s;
+}
+
+.btnAction:hover {
+  opacity: 0.85;
+}
+
+.btnAction:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .btnSend {

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -107,7 +107,7 @@ export function DashboardProfilePage({
           {/* Quick actions */}
           <div className={styles.quickActions}>
             <p className={styles.sectionLabel}>QUICK ACTIONS</p>
-            <button className={styles.btnSend} disabled>
+            <button className={styles.btnSend} onClick={() => onTabChange("transfer")}>
               <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
                 <path
                   d="M2 10H18M12 4L18 10L12 16"

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -774,7 +774,7 @@ export function TransferPage({
               <button className={styles.btnSendAnother} onClick={handleReset}>
                 Send another
               </button>
-              <button className={styles.btnViewActivity} onClick={() => onTabChange("balances")}>
+              <button className={styles.btnViewActivity} onClick={() => onTabChange("activity")}>
                 View in Activity →
               </button>
             </div>


### PR DESCRIPTION
## Summary

- `parseRegistered` in `useRegistration.ts` was still looking for `canton_party_id` in the 409 already-registered response body after `RegisterResult` was renamed to use `party` in PR #38
- This meant users who tried to register an already-registered address would reach the Registration Done page with an empty Party ID and Fingerprint
- Fix reads `p.party ?? p.canton_party_id` so it works across middleware versions
- Same class of regression as the `/profile` → `/user` endpoint fix — stale field name not fully swept during the PR #38 rename

## Test plan

- [ ] Register a fresh address — Party ID and Fingerprint appear correctly on the Registration Done page
- [ ] Attempt to register an already-registered address — 409 path resolves correctly and Party ID and Fingerprint are populated on the Registration Done page