### PR TITLE
ci(snap): force release-as 0.2.1 for the bootstrap release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
       "package-name": "@chainsafe/canton-snap",
       "changelog-path": "CHANGELOG.md",
       "include-paths": ["packages/snap"],
+      "release-as": "0.2.1",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
The first run of \`Release Please\` after #49 merged skipped — log: \`No user facing commits found since - skipping\`.

Root cause: squash-merge collapsed all four PR commits into one. The \`Release-As: 0.2.1\` footer ended up mid-body (followed by the docs trim commit's content), so the conventional-commits parser didn't recognize it as a footer — footers must be at the very end of the message. The top-line type is \`ci:\`, which is hidden in our \`changelog-sections\`, so release-please saw a single non-user-facing commit and skipped.

Fix: add \`"release-as": "0.2.1"\` to the snap package config. This is a one-time override that doesn't depend on commit parsing — release-please reads it on every run and is documented to remove the field automatically as part of the release PR. After 0.2.1 ships, no manual cleanup of this config should be needed; if release-please leaves it behind, a follow-up PR will drop it.

## Test plan

- [ ] On merge, the \`Release Please\` workflow opens \`chore(main): release snap 0.2.1\`.
- [ ] That PR bumps \`packages/snap/package.json\` and \`packages/snap/snap.manifest.json\` to 0.2.1 (no-op, already at 0.2.1) and writes \`packages/snap/CHANGELOG.md\`.
- [ ] That PR also removes \`release-as\` from \`release-please-config.json\`.
- [ ] Merging the release PR creates tag \`snap-v0.2.1\`, the GitHub release, and publishes \`@chainsafe/canton-snap@0.2.1\` via Trusted Publishing.