### PR TITLE
feat(dapp): toggle between published and local snap via VITE_SNAP_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,28 +67,37 @@ canton-snap/
 
 ## Development
 
-**Requires [MetaMask Flask](https://metamask.io/flask/)** — local snaps are rejected by the standard MetaMask extension. Flask is needed until the snap is published to npm. Run it in a dedicated browser profile where the standard MetaMask extension is not installed to avoid `window.ethereum` conflicts.
+The dApp can run against either the published snap on npm (default) or a locally served snap. The mode is controlled by `VITE_SNAP_ID` in `packages/dapp/.env`.
+
+### Mode A — published snap (default, standard MetaMask)
+
+Leave `VITE_SNAP_ID` unset. The dApp uses `npm:@chainsafe/canton-snap` and works with the standard MetaMask extension.
 
 ```bash
 npm install
+cp packages/dapp/.env.example packages/dapp/.env
+npm run dev:dapp
+```
 
-# Copy env templates for each package
+### Mode B — local snap (MetaMask Flask)
+
+Set `VITE_SNAP_ID=local:http://localhost:4040` in `packages/dapp/.env`. Requires [MetaMask Flask](https://metamask.io/flask/) in a dedicated browser profile (standard MetaMask rejects local snaps, and both extensions injecting `window.ethereum` will conflict).
+
+```bash
+npm install
 cp packages/snap/.env.example packages/snap/.env
 cp packages/dapp/.env.example packages/dapp/.env
+# in packages/dapp/.env, uncomment VITE_SNAP_ID=local:http://localhost:4040
 
-# Build snap + dApp
 npm run build
-
-# Start both servers (snap on 4040, dApp on 3000)
-npm run serve
-
-# Or individually:
-npm run serve:snap             # snap dev server
-npm run dev:dapp               # dApp Vite dev server
+npm run serve                  # snap on 4040, dApp on 3000
+# or individually:
+npm run serve:snap
+npm run dev:dapp
 npm run watch:snap             # snap with hot-reload
 ```
 
-`VITE_SNAP_PORT` must match in both `.env` files (default: `4040`).
+The port in `VITE_SNAP_ID` must match `VITE_SNAP_PORT` in `packages/snap/.env` (default `4040`).
 
 See [`docs/testing-with-middleware.md`](docs/testing-with-middleware.md) for the full local setup guide including middleware integration.
 

--- a/docs/testing-with-middleware.md
+++ b/docs/testing-with-middleware.md
@@ -43,7 +43,7 @@ cp packages/snap/.env.example packages/snap/.env
 cp packages/dapp/.env.example packages/dapp/.env
 ```
 
-Edit each `.env` as needed. `VITE_SNAP_PORT` must match in both files (default: `4040`).
+Edit each `.env` as needed. For local snap dev set `VITE_SNAP_ID=local:http://localhost:4040` in `packages/dapp/.env`; the port must match `VITE_SNAP_PORT` in `packages/snap/.env` (default: `4040`).
 
 ---
 

--- a/packages/dapp/.env.example
+++ b/packages/dapp/.env.example
@@ -1,5 +1,6 @@
-# Canton Snap dev server port (must match VITE_SNAP_PORT in packages/snap/.env)
-VITE_SNAP_PORT=4040
+# Snap source. Unset = published `npm:@chainsafe/canton-snap` (standard MetaMask).
+# Set to a local URL to develop against a locally served snap (requires MetaMask Flask):
+# VITE_SNAP_ID=local:http://localhost:4040
 
 # Active Canton network (used for the pill label / color preset: mainnet | devnet | local)
 VITE_NETWORK=devnet

--- a/packages/dapp/src/lib/ethereum.ts
+++ b/packages/dapp/src/lib/ethereum.ts
@@ -1,6 +1,10 @@
 import { getAddress } from "ethers";
 
-export const SNAP_ID = `local:http://localhost:${import.meta.env.VITE_SNAP_PORT ?? 8080}`;
+const PUBLISHED_SNAP_ID = "npm:@chainsafe/canton-snap";
+const PUBLISHED_SNAP_VERSION = "^0.2.0";
+
+export const SNAP_ID = import.meta.env.VITE_SNAP_ID ?? PUBLISHED_SNAP_ID;
+const SNAP_VERSION = SNAP_ID.startsWith("npm:") ? PUBLISHED_SNAP_VERSION : undefined;
 
 declare global {
   interface Window {
@@ -42,7 +46,7 @@ export async function personalSign(message: string, address: string): Promise<st
 export async function installSnap(): Promise<void> {
   await getEthereum().request({
     method: "wallet_requestSnaps",
-    params: { [SNAP_ID]: {} },
+    params: { [SNAP_ID]: SNAP_VERSION ? { version: SNAP_VERSION } : {} },
   });
 }
 

--- a/packages/dapp/src/vite-env.d.ts
+++ b/packages/dapp/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_SNAP_PORT: string;
+  readonly VITE_SNAP_ID?: string;
   readonly VITE_NETWORK?: string;
   readonly VITE_MIDDLEWARE_URL?: string;
 }


### PR DESCRIPTION
## Summary

Lets the dApp run against either the published `npm:@chainsafe/canton-snap` (default, standard MetaMask) or a locally served snap (MetaMask Flask). Mode is controlled by `VITE_SNAP_ID` in `packages/dapp/.env`.

| `VITE_SNAP_ID` | Snap source | MetaMask requirement |
|---|---|---|
| *unset* (default) | `npm:@chainsafe/canton-snap@^0.2.0` | Standard MetaMask |
| `local:http://localhost:4040` | local dev server | MetaMask Flask |

## Changes

- `packages/dapp/src/lib/ethereum.ts` — `SNAP_ID` now derives from `VITE_SNAP_ID` with the published snap as the default. `installSnap()` passes a `version: "^0.2.0"` constraint when (and only when) the snap is the npm one, so MetaMask installs the right semver.
- `packages/dapp/src/vite-env.d.ts` — `VITE_SNAP_PORT` (dapp-side, now unused) replaced with `VITE_SNAP_ID`. `VITE_SNAP_PORT` remains in `packages/snap/.env` for `mm-snap serve`.
- `packages/dapp/.env.example`, `README.md`, `docs/testing-with-middleware.md` — document both modes.

## Release impact

None. `release-please-config.json` has `include-paths: ["packages/snap"]`, so this dapp-only PR will not open a snap release PR. The dApp will get its own release pipeline later.

## Local migration

Anyone with an existing `packages/dapp/.env` should replace `VITE_SNAP_PORT=4040` with either:

- `VITE_SNAP_ID=local:http://localhost:4040` to keep running against the local snap server, or
- delete/comment the line to run against the published 0.2.0.

## Test plan

- [ ] `npm install && npm run dev:dapp` with default `.env` (no `VITE_SNAP_ID`) — dApp opens, "Connect Snap" triggers MetaMask's install dialog for `npm:@chainsafe/canton-snap` at version `^0.2.0`.
- [ ] After install, `wallet_getSnaps` returns the npm snap; basic flows (fingerprint export, sign hash) work end to end against the production snap.
- [ ] Set `VITE_SNAP_ID=local:http://localhost:4040`, run `npm run serve` (with MetaMask Flask in a clean profile) — dApp connects to the local snap; the same flows work against the dev bundle.
- [ ] `npm -w packages/dapp run build` succeeds (already verified locally).