### PR TITLE
feat(dapp): add Dockerfile, nginx config, and CI pipeline for Kubernetes deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/node_modules
+**/dist
+.env
+.env.*
+.git
+.github

--- a/.github/workflows/dapp-docker.yml
+++ b/.github/workflows/dapp-docker.yml
@@ -1,0 +1,48 @@
+name: Build and push dapp Docker image
+
+on:
+  push:
+    tags:
+      - 'dapp-v*'
+
+concurrency:
+  group: dapp-docker-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/chainsafe/canton-dapp
+          tags: |
+            type=match,pattern=dapp-v(.*),group=1
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/dapp/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/packages/dapp/Dockerfile
+++ b/packages/dapp/Dockerfile
@@ -10,15 +10,19 @@ RUN npm ci
 # Copy dapp source (snap source not needed for dapp build)
 COPY packages/dapp packages/dapp
 
-# Write placeholder env values — replaced at container startup via entrypoint.sh
+# Write placeholder env values — replaced at container startup via docker-entrypoint.d
 RUN printf 'VITE_MIDDLEWARE_URL=__VITE_MIDDLEWARE_URL__\nVITE_NETWORK=__VITE_NETWORK__\n' > .env
 
 RUN npm run build:dapp
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
-COPY --from=builder /app/packages/dapp/dist /usr/share/nginx/html
+# Remove the root-owned html dir so the COPY below creates a nginx-owned one,
+# allowing sed -i (which needs to create temp files in the directory) to succeed.
+USER root
+RUN rm -rf /usr/share/nginx/html
+COPY --chown=nginx:nginx --from=builder /app/packages/dapp/dist /usr/share/nginx/html
+USER nginx
 COPY packages/dapp/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --chmod=0755 packages/dapp/docker-entrypoint.sh /docker-entrypoint.sh
+COPY --chmod=0755 packages/dapp/docker-entrypoint.sh /docker-entrypoint.d/40-env-injection.sh
 
 EXPOSE 8080
-ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/packages/dapp/Dockerfile
+++ b/packages/dapp/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20.18-alpine AS builder
+WORKDIR /app
+
+# Copy workspace manifests first for layer caching
+COPY package.json package-lock.json tsconfig.base.json ./
+COPY packages/dapp/package.json packages/dapp/
+COPY packages/snap/package.json packages/snap/
+RUN npm ci
+
+# Copy dapp source (snap source not needed for dapp build)
+COPY packages/dapp packages/dapp
+
+# Write placeholder env values — replaced at container startup via entrypoint.sh
+RUN printf 'VITE_MIDDLEWARE_URL=__VITE_MIDDLEWARE_URL__\nVITE_NETWORK=__VITE_NETWORK__\n' > .env
+
+RUN npm run build:dapp
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine
+COPY --from=builder /app/packages/dapp/dist /usr/share/nginx/html
+COPY packages/dapp/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --chmod=0755 packages/dapp/docker-entrypoint.sh /docker-entrypoint.sh
+
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/packages/dapp/docker-entrypoint.sh
+++ b/packages/dapp/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+if [ -z "$VITE_MIDDLEWARE_URL" ]; then
+  echo "ERROR: VITE_MIDDLEWARE_URL is not set" >&2
+  exit 1
+fi
+
+if [ -z "$VITE_NETWORK" ]; then
+  echo "ERROR: VITE_NETWORK is not set" >&2
+  exit 1
+fi
+
+# Escape characters that are special in sed replacement strings (\ & |)
+escape_sed() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+ESC_URL=$(escape_sed "$VITE_MIDDLEWARE_URL")
+ESC_NETWORK=$(escape_sed "$VITE_NETWORK")
+
+find /usr/share/nginx/html \( -name '*.js' -o -name '*.html' -o -name '*.css' \) \
+  -exec sed -i \
+    -e "s|__VITE_MIDDLEWARE_URL__|${ESC_URL}|g" \
+    -e "s|__VITE_NETWORK__|${ESC_NETWORK}|g" \
+  {} +
+
+exec nginx -g 'daemon off;'

--- a/packages/dapp/docker-entrypoint.sh
+++ b/packages/dapp/docker-entrypoint.sh
@@ -24,5 +24,3 @@ find /usr/share/nginx/html \( -name '*.js' -o -name '*.html' -o -name '*.css' \)
     -e "s|__VITE_MIDDLEWARE_URL__|${ESC_URL}|g" \
     -e "s|__VITE_NETWORK__|${ESC_NETWORK}|g" \
   {} +
-
-exec nginx -g 'daemon off;'

--- a/packages/dapp/nginx.conf
+++ b/packages/dapp/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 8080;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+
+    # Hashed assets are immutable — cache aggressively
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # SPA entry point — always revalidate so users get new asset hashes on deploy
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    # SPA routing — all unknown paths serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /health {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+}

--- a/packages/dapp/nginx.conf
+++ b/packages/dapp/nginx.conf
@@ -5,19 +5,26 @@ server {
 
     gzip on;
     gzip_proxied any;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
 
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Content-Type-Options "nosniff";
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
+    # Security headers applied to all responses
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # Hashed assets are immutable — cache aggressively
     location /assets/ {
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     # SPA entry point — always revalidate so users get new asset hashes on deploy
     location = /index.html {
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Cache-Control "no-cache";
     }
 


### PR DESCRIPTION
## Summary

- Multi-stage Dockerfile: Node 20.18 builder → `nginxinc/nginx-unprivileged:1.27-alpine`
- Runtime `VITE_*` env var injection via `sed` at container startup — single image works across all environments
- nginx config with SPA routing, cache headers, and `/health` endpoint
- GitHub Actions workflow: builds and pushes `ghcr.io/chainsafe/canton-dapp:<version>` on `dapp-v*` tags

## Test plan

- [ ] CI builds successfully on this branch
- [ ] Image published to `ghcr.io/chainsafe/canton-dapp` after tag push
- [ ] Container starts with `VITE_MIDDLEWARE_URL` and `VITE_NETWORK` set
- [ ] Dapp accessible at `https://dapp-dev1.01.chainsafe.dev` after Kubernetes deployment

Refs #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)