### PR TITLE
fix(ci): fix workflow_dispatch tag computation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 **/node_modules
 **/dist
-.env
-.env.*
+**/.env
+**/.env.*
 .git
 .github

--- a/.github/workflows/dapp-docker.yml
+++ b/.github/workflows/dapp-docker.yml
@@ -36,14 +36,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute image version
+        id: version
+        run: |
+          INPUT="${{ github.event.inputs.tag }}"
+          REF="${{ github.ref_name }}"
+          if [ -n "$INPUT" ]; then
+            VERSION="${INPUT#dapp-v}"
+          elif [[ "$REF" == dapp-v* ]]; then
+            VERSION="${REF#dapp-v}"
+          else
+            VERSION=""
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # not a pre-release if version contains no hyphen
+          [[ "$VERSION" != *-* ]] && IS_LATEST=true || IS_LATEST=false
+          echo "is_latest=$IS_LATEST" >> $GITHUB_OUTPUT
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/chainsafe/canton-dapp
           tags: |
-            type=match,pattern=dapp-v(.*),group=1
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
+            type=raw,value=latest,enable=${{ steps.version.outputs.is_latest == 'true' && steps.version.outputs.version != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/dapp-docker.yml
+++ b/.github/workflows/dapp-docker.yml
@@ -38,9 +38,10 @@ jobs:
 
       - name: Compute image version
         id: version
+        env:
+          INPUT: ${{ github.event.inputs.tag }}
+          REF: ${{ github.ref_name }}
         run: |
-          INPUT="${{ github.event.inputs.tag }}"
-          REF="${{ github.ref_name }}"
           if [ -n "$INPUT" ]; then
             VERSION="${INPUT#dapp-v}"
           elif [[ "$REF" == dapp-v* ]]; then
@@ -49,9 +50,11 @@ jobs:
             VERSION=""
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          # not a pre-release if version contains no hyphen
-          [[ "$VERSION" != *-* ]] && IS_LATEST=true || IS_LATEST=false
-          echo "is_latest=$IS_LATEST" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" != *-* ]]; then
+            echo "is_latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_latest=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/dapp-docker.yml
+++ b/.github/workflows/dapp-docker.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/dapp-docker.yml
+++ b/.github/workflows/dapp-docker.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'dapp-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. dapp-v1.1.0)'
+        required: true
 
 concurrency:
   group: dapp-docker-${{ github.ref }}
@@ -18,6 +23,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/packages/dapp/Dockerfile
+++ b/packages/dapp/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci
 COPY packages/dapp packages/dapp
 
 # Write placeholder env values — replaced at container startup via docker-entrypoint.d
-RUN printf 'VITE_MIDDLEWARE_URL=__VITE_MIDDLEWARE_URL__\nVITE_NETWORK=__VITE_NETWORK__\n' > .env
+RUN printf 'VITE_MIDDLEWARE_URL=__VITE_MIDDLEWARE_URL__\nVITE_NETWORK=__VITE_NETWORK__\nVITE_SNAP_ID=__VITE_SNAP_ID__\nVITE_ENABLE_NON_CUSTODIAL=__VITE_ENABLE_NON_CUSTODIAL__\n' > .env
 
 RUN npm run build:dapp
 

--- a/packages/dapp/docker-entrypoint.sh
+++ b/packages/dapp/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -eu
 
-if [ -z "$VITE_MIDDLEWARE_URL" ]; then
+if [ -z "${VITE_MIDDLEWARE_URL:-}" ]; then
   echo "ERROR: VITE_MIDDLEWARE_URL is not set" >&2
   exit 1
 fi
 
-if [ -z "$VITE_NETWORK" ]; then
+if [ -z "${VITE_NETWORK:-}" ]; then
   echo "ERROR: VITE_NETWORK is not set" >&2
   exit 1
 fi
@@ -19,8 +19,13 @@ escape_sed() {
 ESC_URL=$(escape_sed "$VITE_MIDDLEWARE_URL")
 ESC_NETWORK=$(escape_sed "$VITE_NETWORK")
 
-find /usr/share/nginx/html \( -name '*.js' -o -name '*.html' -o -name '*.css' \) \
+ESC_SNAP_ID=$(escape_sed "${VITE_SNAP_ID:-}")
+ESC_NON_CUSTODIAL=$(escape_sed "${VITE_ENABLE_NON_CUSTODIAL:-}")
+
+find /usr/share/nginx/html \( -name '*.js' -o -name '*.html' -o -name '*.css' -o -name '*.map' \) \
   -exec sed -i \
     -e "s|__VITE_MIDDLEWARE_URL__|${ESC_URL}|g" \
     -e "s|__VITE_NETWORK__|${ESC_NETWORK}|g" \
+    -e "s|__VITE_SNAP_ID__|${ESC_SNAP_ID}|g" \
+    -e "s|__VITE_ENABLE_NON_CUSTODIAL__|${ESC_NON_CUSTODIAL}|g" \
   {} +


### PR DESCRIPTION
## Summary

`workflow_dispatch` was only creating `:latest` tag because `github.ref_name` equals `main` during manual dispatch — `type=match,pattern=dapp-v(.*)` never matched.

Fix: add an explicit `compute-version` step that extracts the version from either the `workflow_dispatch` input or the git tag ref, then pass it directly to `metadata-action`.

## Test plan

- [ ] Merge and trigger via Actions → "Build and push dapp Docker image" → Run workflow → tag: `dapp-v1.1.0`
- [ ] Image `ghcr.io/chainsafe/canton-dapp:1.1.0` appears in ghcr.io

Refs #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)