### PR TITLE
feat(dapp): handle async eth_sendRawTransaction + tx status in Activity

### DIFF
--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -60,6 +60,49 @@ export async function ethChainId(rpcUrl: string): Promise<string> {
   return json.result as string;
 }
 
+export interface TxReceipt {
+  status: "success" | "failed";
+  blockNumber: number;
+  revertReason?: string;
+}
+
+// Returns null while the tx is still pending in the mempool. canton-middleware
+// PR #281 made `eth_sendRawTransaction` async, so a hash is returned before the
+// receipt exists. `revertReason` is a non-standard field surfaced for
+// status=0 receipts so we can show the Canton-side error.
+export async function getTransactionReceipt(
+  rpcUrl: string,
+  txHash: string,
+): Promise<TxReceipt | null> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_getTransactionReceipt",
+      params: [txHash],
+      id: ++_rpcId,
+    }),
+  });
+  if (!res.ok) throw new Error(`RPC error ${res.status}: ${await res.text()}`);
+  const json = (await res.json()) as {
+    result?: {
+      status?: string;
+      blockNumber?: string;
+      revertReason?: string;
+    } | null;
+    error?: { message: string };
+  };
+  if (json.error) throw new Error(json.error.message);
+  if (!json.result) return null;
+  const status = json.result.status === "0x1" ? "success" : "failed";
+  return {
+    status,
+    blockNumber: json.result.blockNumber ? parseInt(json.result.blockNumber, 16) : 0,
+    revertReason: json.result.revertReason,
+  };
+}
+
 interface RawLog {
   address: string;
   topics: string[];

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -92,7 +92,8 @@ export async function getTransactionReceipt(
       revertReason?: string;
     } | null;
     error?: { message: string };
-  };
+  } | null;
+  if (!json || typeof json !== "object") throw new Error("Invalid RPC response");
   if (json.error) throw new Error(json.error.message);
   if (!json.result) return null;
   const status = json.result.status === "0x1" ? "success" : "failed";

--- a/packages/dapp/src/lib/pendingTxs.ts
+++ b/packages/dapp/src/lib/pendingTxs.ts
@@ -1,0 +1,80 @@
+// Tracks locally-submitted outgoing transfers whose receipt hasn't arrived yet.
+// canton-middleware PR #281 made `eth_sendRawTransaction` async — the API
+// returns a tx hash immediately and the Canton transfer is run by a background
+// submitter. Until the miner seals the entry, eth_getLogs has no Transfer log
+// for it, so the Activity tab would otherwise show nothing. We persist enough
+// metadata in localStorage to render a "pending" row in the meantime.
+
+const STORAGE_PREFIX = "canton-pending-txs:";
+
+export interface PendingTx {
+  txHash: string;
+  tokenAddress: string;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  // ERC-20 raw amount as decimal string (bigint doesn't survive JSON)
+  amount: string;
+  from: string;
+  to: string;
+  // Unix seconds; when the entry was submitted from this client
+  submittedAt: number;
+  status: "pending" | "failed";
+  revertReason?: string;
+}
+
+function storageKey(address: string): string {
+  return STORAGE_PREFIX + address.toLowerCase();
+}
+
+function readAll(address: string): PendingTx[] {
+  try {
+    const raw = localStorage.getItem(storageKey(address));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is PendingTx =>
+        typeof e === "object" &&
+        e !== null &&
+        typeof (e as PendingTx).txHash === "string" &&
+        typeof (e as PendingTx).tokenAddress === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(address: string, entries: PendingTx[]): void {
+  try {
+    localStorage.setItem(storageKey(address), JSON.stringify(entries));
+  } catch {
+    // localStorage quota / disabled — silently drop; pending UI is best-effort
+  }
+}
+
+export function getPendingTxs(address: string): PendingTx[] {
+  return readAll(address);
+}
+
+export function recordPendingTx(address: string, entry: Omit<PendingTx, "status">): void {
+  const existing = readAll(address);
+  if (existing.some((e) => e.txHash.toLowerCase() === entry.txHash.toLowerCase())) return;
+  const next = [...existing, { ...entry, status: "pending" as const }];
+  writeAll(address, next);
+}
+
+export function markPendingFailed(address: string, txHash: string, revertReason?: string): void {
+  const existing = readAll(address);
+  const next = existing.map((e) =>
+    e.txHash.toLowerCase() === txHash.toLowerCase()
+      ? { ...e, status: "failed" as const, revertReason }
+      : e,
+  );
+  writeAll(address, next);
+}
+
+export function removePendingTx(address: string, txHash: string): void {
+  const existing = readAll(address);
+  const next = existing.filter((e) => e.txHash.toLowerCase() !== txHash.toLowerCase());
+  writeAll(address, next);
+}

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -131,10 +131,64 @@
   color: #60a5fa;
 }
 
+.typeStack {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
 .typeLabel {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.statusPillPending {
+  background: color-mix(in srgb, var(--amber) 14%, transparent);
+  color: var(--amber);
+  border: 1px solid color-mix(in srgb, var(--amber) 35%, transparent);
+}
+
+.statusPillFailed {
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+  color: var(--red);
+  border: 1px solid color-mix(in srgb, var(--red) 35%, transparent);
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: pendingPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pendingPulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+.rowPending .amountValue {
+  color: var(--amber);
+}
+
+.rowFailed .amountValue {
+  color: var(--text-muted);
+  text-decoration: line-through;
 }
 
 /* Token cell */

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -282,9 +282,15 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
     const pendingRows = pending
       .filter((p) => !confirmedHashes.has(p.txHash.toLowerCase()))
       .map(pendingToRow);
-    // Pending rows use MAX_SAFE_INTEGER as blockNumber so they sort to the top.
+    // Sort by timestamp (newest first) so failed entries fall into their
+    // historical day group rather than always sorting to the top. Within the
+    // same block, logIndex breaks ties. blockNumber is a tertiary key for the
+    // rare case of two confirmed blocks sharing a timestamp.
     return [...pendingRows, ...confirmed].sort(
-      (a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex,
+      (a, b) =>
+        b.timestamp - a.timestamp ||
+        b.blockNumber - a.blockNumber ||
+        b.logIndex - a.logIndex,
     );
   }, [fetchState, pending]);
 
@@ -300,12 +306,13 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
     );
   }, [merged, search]);
 
-  // Group rows by calendar day. Pending entries land in their own group at the
-  // top since their block-relative timestamp isn't tied to a confirmed block.
+  // Group rows by calendar day. Only in-flight pending entries land in the
+  // dedicated PENDING group; failed entries fall into their submission-day
+  // group so the resolved-but-unsuccessful history stays chronological.
   const groups = useMemo(() => {
     const map = new Map<string, ActivityRow[]>();
     for (const row of filtered) {
-      const key = row.status === "confirmed" ? dayKey(row.timestamp) : "__pending__";
+      const key = row.status === "pending" ? "__pending__" : dayKey(row.timestamp);
       const arr = map.get(key) ?? [];
       arr.push(row);
       map.set(key, arr);

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -288,9 +288,7 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
     // rare case of two confirmed blocks sharing a timestamp.
     return [...pendingRows, ...confirmed].sort(
       (a, b) =>
-        b.timestamp - a.timestamp ||
-        b.blockNumber - a.blockNumber ||
-        b.logIndex - a.logIndex,
+        b.timestamp - a.timestamp || b.blockNumber - a.blockNumber || b.logIndex - a.logIndex,
     );
   }, [fetchState, pending]);
 
@@ -409,9 +407,7 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
                             {isSent ? <ArrowUpIcon /> : <ArrowDownIcon />}
                           </div>
                           <div className={styles.typeStack}>
-                            <span className={styles.typeLabel}>
-                              {isSent ? "Sent" : "Received"}
-                            </span>
+                            <span className={styles.typeLabel}>{isSent ? "Sent" : "Received"}</span>
                             {isPending && (
                               <span className={`${styles.statusPill} ${styles.statusPillPending}`}>
                                 <span className={styles.statusDot} />

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -4,7 +4,18 @@ import { DashboardLayout, type DashboardTab } from "../components/DashboardLayou
 import { Spinner } from "../components/Spinner";
 import { NETWORK } from "../lib/config";
 import { getTokens, type TokenConfig } from "../lib/middleware";
-import { getTransferLogs, formatTokenAmount, type TransferLog } from "../lib/ethrpc";
+import {
+  getTransferLogs,
+  getTransactionReceipt,
+  formatTokenAmount,
+  type TransferLog,
+} from "../lib/ethrpc";
+import {
+  getPendingTxs,
+  removePendingTx,
+  markPendingFailed,
+  type PendingTx,
+} from "../lib/pendingTxs";
 import { TOKEN_COLORS } from "../lib/tokens";
 import { toChecksumAddress, shortenAddress } from "../lib/ethereum";
 import { CopyButton } from "../components/CopyButton";
@@ -17,13 +28,42 @@ interface Props {
   onDisconnect: () => void;
 }
 
+type RowStatus = "confirmed" | "pending" | "failed";
+
 interface ActivityRow extends TransferLog {
   token: TokenConfig;
+  status: RowStatus;
+  revertReason?: string;
 }
 
 type FetchState =
   | { url: string; address: string; rows: ActivityRow[]; error: null }
   | { url: string; address: string; rows: null; error: string };
+
+const RECEIPT_POLL_INTERVAL_MS = 4000;
+
+function pendingToRow(p: PendingTx): ActivityRow {
+  return {
+    txHash: p.txHash,
+    // Pending entries have no block yet; sentinel keeps sort order (newest first).
+    blockNumber: Number.MAX_SAFE_INTEGER,
+    logIndex: 0,
+    timestamp: p.submittedAt,
+    direction: "sent",
+    tokenAddress: p.tokenAddress,
+    amount: BigInt(p.amount),
+    from: p.from,
+    to: p.to,
+    token: {
+      address: p.tokenAddress,
+      name: p.tokenSymbol,
+      symbol: p.tokenSymbol,
+      decimals: p.tokenDecimals,
+    },
+    status: p.status === "failed" ? "failed" : "pending",
+    revertReason: p.revertReason,
+  };
+}
 
 // Jan 1 2020 in Unix seconds — anything before this is a synthetic/bogus timestamp
 const MIN_REAL_TIMESTAMP = 1577836800;
@@ -117,6 +157,20 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
   const [fetchState, setFetchState] = useState<FetchState | null>(null);
   const [search, setSearch] = useState("");
 
+  // Bump to re-read the pending store (localStorage) or re-fetch confirmed logs.
+  // Pending is derived state, not local state — the source of truth is
+  // localStorage. Components that mutate the store (TransferPage, the polling
+  // callback below) write to localStorage, then we read it back here.
+  const [pendingTick, setPendingTick] = useState(0);
+  const [logsTick, setLogsTick] = useState(0);
+
+  const pending = useMemo(
+    () => getPendingTxs(address),
+    // pendingTick re-runs the read when the store mutates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [address, pendingTick],
+  );
+
   const loading = fetchState?.url !== NETWORK.middlewareUrl || fetchState?.address !== address;
 
   useEffect(() => {
@@ -133,14 +187,29 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
           address,
         );
         const rows: ActivityRow[] = logs
-          .map((log) => {
+          .map((log): ActivityRow | null => {
             const token = tokenByAddress.get(log.tokenAddress);
             if (!token) return null;
-            return { ...log, token };
+            return { ...log, token, status: "confirmed" };
           })
           .filter((r): r is ActivityRow => r !== null);
 
-        if (!cancelled) setFetchState({ url: NETWORK.middlewareUrl, address, rows, error: null });
+        if (cancelled) return;
+
+        // Drop pending entries whose confirmed Transfer log just arrived —
+        // covers reloads after the receipt landed and any poll the user
+        // missed because the tab was hidden.
+        const confirmedHashes = new Set(rows.map((r) => r.txHash.toLowerCase()));
+        let removed = false;
+        for (const p of getPendingTxs(address)) {
+          if (confirmedHashes.has(p.txHash.toLowerCase())) {
+            removePendingTx(address, p.txHash);
+            removed = true;
+          }
+        }
+
+        setFetchState({ url: NETWORK.middlewareUrl, address, rows, error: null });
+        if (removed) setPendingTick((t) => t + 1);
       } catch (e: unknown) {
         if (!cancelled)
           setFetchState({
@@ -156,26 +225,87 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
     return () => {
       cancelled = true;
     };
-  }, [address]);
+  }, [address, logsTick]);
+
+  // Poll receipts for entries still in "pending" status. Once a receipt arrives:
+  //   status=1 → remove (a confirmed log will appear on next refresh)
+  //   status=0 → mark failed and keep so the user sees the outcome
+  const hasUnresolved = pending.some((p) => p.status === "pending");
+
+  useEffect(() => {
+    if (!hasUnresolved) return;
+
+    const rpcUrl = `${NETWORK.middlewareUrl}/eth`;
+    let cancelled = false;
+
+    async function poll() {
+      const snapshot = getPendingTxs(address).filter((p) => p.status === "pending");
+      if (snapshot.length === 0) return;
+      const results = await Promise.all(
+        snapshot.map(async (p) => {
+          try {
+            return [p, await getTransactionReceipt(rpcUrl, p.txHash)] as const;
+          } catch {
+            return [p, null] as const;
+          }
+        }),
+      );
+      if (cancelled) return;
+
+      let resolvedAny = false;
+      for (const [p, receipt] of results) {
+        if (!receipt) continue;
+        resolvedAny = true;
+        if (receipt.status === "success") {
+          removePendingTx(address, p.txHash);
+        } else {
+          markPendingFailed(address, p.txHash, receipt.revertReason);
+        }
+      }
+      if (resolvedAny) {
+        setPendingTick((t) => t + 1);
+        setLogsTick((t) => t + 1);
+      }
+    }
+
+    void poll();
+    const id = window.setInterval(() => void poll(), RECEIPT_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [hasUnresolved, address]);
+
+  const merged = useMemo(() => {
+    const confirmed = fetchState?.rows ?? [];
+    const confirmedHashes = new Set(confirmed.map((r) => r.txHash.toLowerCase()));
+    const pendingRows = pending
+      .filter((p) => !confirmedHashes.has(p.txHash.toLowerCase()))
+      .map(pendingToRow);
+    // Pending rows use MAX_SAFE_INTEGER as blockNumber so they sort to the top.
+    return [...pendingRows, ...confirmed].sort(
+      (a, b) => b.blockNumber - a.blockNumber || b.logIndex - a.logIndex,
+    );
+  }, [fetchState, pending]);
 
   const filtered = useMemo(() => {
-    const rows = fetchState?.rows ?? [];
     const q = search.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter(
+    if (!q) return merged;
+    return merged.filter(
       (r) =>
         r.txHash.toLowerCase().includes(q) ||
         r.from.toLowerCase().includes(q) ||
         r.to.toLowerCase().includes(q) ||
         r.token.symbol.toLowerCase().includes(q),
     );
-  }, [fetchState, search]);
+  }, [merged, search]);
 
-  // Group rows by calendar day
+  // Group rows by calendar day. Pending entries land in their own group at the
+  // top since their block-relative timestamp isn't tied to a confirmed block.
   const groups = useMemo(() => {
     const map = new Map<string, ActivityRow[]>();
     for (const row of filtered) {
-      const key = dayKey(row.timestamp);
+      const key = row.status === "confirmed" ? dayKey(row.timestamp) : "__pending__";
       const arr = map.get(key) ?? [];
       arr.push(row);
       map.set(key, arr);
@@ -248,16 +378,22 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
             filtered.length > 0 &&
             groups.map(({ key, rows }) => (
               <div key={key}>
-                <div className={styles.dayGroup}>{dayLabel(rows[0].timestamp)}</div>
+                <div className={styles.dayGroup}>
+                  {key === "__pending__" ? "PENDING" : dayLabel(rows[0].timestamp)}
+                </div>
                 {rows.map((row, i) => {
                   const isSent = row.direction === "sent";
                   const counterparty = toChecksumAddress(isSent ? row.to : row.from);
                   const shortTx = `${row.txHash.slice(0, 10)}…${row.txHash.slice(-8)}`;
+                  const isPending = row.status === "pending";
+                  const isFailed = row.status === "failed";
 
                   return (
                     <div key={`${row.txHash}-${row.logIndex}`}>
                       {i > 0 && <div className={styles.rowDivider} />}
-                      <div className={styles.activityRow}>
+                      <div
+                        className={`${styles.activityRow} ${isPending ? styles.rowPending : ""} ${isFailed ? styles.rowFailed : ""}`}
+                      >
                         {/* Type */}
                         <div className={styles.typeCell}>
                           <div
@@ -265,7 +401,25 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
                           >
                             {isSent ? <ArrowUpIcon /> : <ArrowDownIcon />}
                           </div>
-                          <span className={styles.typeLabel}>{isSent ? "Sent" : "Received"}</span>
+                          <div className={styles.typeStack}>
+                            <span className={styles.typeLabel}>
+                              {isSent ? "Sent" : "Received"}
+                            </span>
+                            {isPending && (
+                              <span className={`${styles.statusPill} ${styles.statusPillPending}`}>
+                                <span className={styles.statusDot} />
+                                Pending
+                              </span>
+                            )}
+                            {isFailed && (
+                              <span
+                                className={`${styles.statusPill} ${styles.statusPillFailed}`}
+                                title={row.revertReason}
+                              >
+                                Failed
+                              </span>
+                            )}
+                          </div>
                         </div>
 
                         {/* Token */}
@@ -308,9 +462,13 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
                         <div className={styles.whenCell}>
                           <span className={styles.whenRelative}>{relativeTime(row.timestamp)}</span>
                           <span className={styles.whenAbsolute}>
-                            {row.timestamp >= MIN_REAL_TIMESTAMP
-                              ? timeUTC(row.timestamp)
-                              : `Block #${row.blockNumber}`}
+                            {isPending
+                              ? "Awaiting receipt"
+                              : isFailed
+                                ? "Reverted"
+                                : row.timestamp >= MIN_REAL_TIMESTAMP
+                                  ? timeUTC(row.timestamp)
+                                  : `Block #${row.blockNumber}`}
                           </span>
                         </div>
                       </div>

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -673,6 +673,16 @@
   box-shadow: 0 0 48px rgba(0, 212, 164, 0.28);
 }
 
+.checkCirclePending {
+  background: linear-gradient(135deg, #ffd47a 0%, var(--amber) 100%);
+  box-shadow: 0 0 48px rgba(255, 184, 77, 0.28);
+}
+
+.checkCircleFailed {
+  background: linear-gradient(135deg, #ff8a8a 0%, var(--red) 100%);
+  box-shadow: 0 0 48px rgba(255, 107, 107, 0.28);
+}
+
 .doneTitle {
   font-size: 26px;
   font-weight: 700;

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -9,15 +9,20 @@ import {
   getTokenBalance,
   formatTokenAmount,
   encodeTransfer,
+  getTransactionReceipt,
   parseTokenAmount,
 } from "../lib/ethrpc";
 import { prepareTransfer, executeTransfer, type PrepareResult } from "../lib/transfer";
 import { sendEthTransaction, shortenAddress, toChecksumAddress } from "../lib/ethereum";
 import { ensureChainAdded } from "../lib/network";
 import { TOKEN_COLORS } from "../lib/tokens";
+import { recordPendingTx, removePendingTx, markPendingFailed } from "../lib/pendingTxs";
 import { useSnap } from "../hooks/useSnap";
 import { cn } from "../lib/cn";
 import styles from "./TransferPage.module.css";
+
+type ReceiptStatus = "pending" | "success" | "failed";
+const RECEIPT_POLL_INTERVAL_MS = 3000;
 
 type Step = "details" | "sign" | "done";
 type SignPhase = "idle" | "preparing" | "awaiting-snap" | "signing" | "executing";
@@ -235,6 +240,8 @@ export function TransferPage({ address, activeTab, onTabChange, onDisconnect, ke
   const [signPhase, setSignPhase] = useState<SignPhase>("idle");
   const [prepared, setPrepared] = useState<PrepareResult | null>(null);
   const [receipt, setReceipt] = useState<Receipt | null>(null);
+  const [receiptStatus, setReceiptStatus] = useState<ReceiptStatus>("pending");
+  const [revertReason, setRevertReason] = useState<string | undefined>();
 
   const snap = useSnap();
   const isNonCustodial = keyMode === "external";
@@ -369,6 +376,16 @@ export function TransferPage({ address, activeTab, onTabChange, onDisconnect, ke
         fingerprint,
       );
 
+      recordPendingTx(address, {
+        txHash: prepared.transactionHash,
+        tokenAddress: selectedToken.address.toLowerCase(),
+        tokenSymbol: selectedToken.symbol,
+        tokenDecimals: selectedToken.decimals,
+        amount: parseTokenAmount(amount, selectedToken.decimals).toString(),
+        from: address.toLowerCase(),
+        to: recipient.toLowerCase(),
+        submittedAt: Math.floor(Date.now() / 1000),
+      });
       setReceipt({ txHash: prepared.transactionHash, token: selectedToken, amount, to: recipient });
       setStep("done");
     } catch (e: unknown) {
@@ -392,6 +409,16 @@ export function TransferPage({ address, activeTab, onTabChange, onDisconnect, ke
       const data = encodeTransfer(recipient, amountBigInt);
       const txHash = await sendEthTransaction({ from: address, to: selectedToken.address, data });
 
+      recordPendingTx(address, {
+        txHash,
+        tokenAddress: selectedToken.address.toLowerCase(),
+        tokenSymbol: selectedToken.symbol,
+        tokenDecimals: selectedToken.decimals,
+        amount: amountBigInt.toString(),
+        from: address.toLowerCase(),
+        to: recipient.toLowerCase(),
+        submittedAt: Math.floor(Date.now() / 1000),
+      });
       setReceipt({ txHash, token: selectedToken, amount, to: recipient });
       setStep("done");
     } catch (e: unknown) {
@@ -409,7 +436,43 @@ export function TransferPage({ address, activeTab, onTabChange, onDisconnect, ke
     setSignPhase("idle");
     setError(null);
     setReceipt(null);
+    setReceiptStatus("pending");
+    setRevertReason(undefined);
   }
+
+  // Poll eth_getTransactionReceipt while the Done step is showing a pending tx.
+  // canton-middleware PR #281 made tx submission async, so the receipt arrives
+  // a few seconds after the hash returns. Mirrors the polling on the Activity
+  // tab so the pending entry there clears in lockstep with the UI here.
+  useEffect(() => {
+    if (step !== "done" || !receipt || receiptStatus !== "pending") return;
+    const rpcUrl = `${NETWORK.middlewareUrl}/eth`;
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const r = await getTransactionReceipt(rpcUrl, receipt!.txHash);
+        if (cancelled || !r) return;
+        if (r.status === "success") {
+          removePendingTx(address, receipt!.txHash);
+          setReceiptStatus("success");
+        } else {
+          markPendingFailed(address, receipt!.txHash, r.revertReason);
+          setRevertReason(r.revertReason);
+          setReceiptStatus("failed");
+        }
+      } catch {
+        // transient — try again on next tick
+      }
+    }
+
+    void poll();
+    const id = window.setInterval(() => void poll(), RECEIPT_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [step, receipt, receiptStatus, address]);
 
   async function handlePaste() {
     try {
@@ -708,20 +771,51 @@ export function TransferPage({ address, activeTab, onTabChange, onDisconnect, ke
         {/* ── Done step ── */}
         {step === "done" && receipt && (
           <PageCard className={styles.doneCard}>
-            <div className={styles.checkCircle}>
-              <svg width="28" height="20" viewBox="0 0 28 20" fill="none">
-                <path
-                  d="M2 10L10 18L26 2"
-                  stroke="#0a0b14"
-                  strokeWidth="3.4"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+            <div
+              className={cn(
+                styles.checkCircle,
+                receiptStatus === "pending" && styles.checkCirclePending,
+                receiptStatus === "failed" && styles.checkCircleFailed,
+              )}
+            >
+              {receiptStatus === "pending" ? (
+                <Spinner />
+              ) : receiptStatus === "failed" ? (
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M6 6L18 18M18 6L6 18"
+                    stroke="#0a0b14"
+                    strokeWidth="3.4"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              ) : (
+                <svg width="28" height="20" viewBox="0 0 28 20" fill="none">
+                  <path
+                    d="M2 10L10 18L26 2"
+                    stroke="#0a0b14"
+                    strokeWidth="3.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
             </div>
 
-            <p className={styles.doneTitle}>Transfer sent</p>
-            <p className={styles.doneSubtitle}>Transfer confirmed on Canton Network.</p>
+            <p className={styles.doneTitle}>
+              {receiptStatus === "pending"
+                ? "Transfer submitted"
+                : receiptStatus === "failed"
+                  ? "Transfer failed"
+                  : "Transfer sent"}
+            </p>
+            <p className={styles.doneSubtitle}>
+              {receiptStatus === "pending"
+                ? "Awaiting confirmation on Canton Network…"
+                : receiptStatus === "failed"
+                  ? (revertReason ?? "Reverted on Canton Network.")
+                  : "Transfer confirmed on Canton Network."}
+            </p>
 
             <div className={styles.receipt}>
               <div className={styles.receiptRow}>
@@ -739,8 +833,14 @@ export function TransferPage({ address, activeTab, onTabChange, onDisconnect, ke
                 <span className={styles.receiptValue}>{receipt.txHash}</span>
               </div>
               <div className={styles.receiptRow}>
-                <span className={styles.receiptLabel}>Completed</span>
-                <span className={styles.receiptValue}>Just now</span>
+                <span className={styles.receiptLabel}>Status</span>
+                <span className={styles.receiptValue}>
+                  {receiptStatus === "pending"
+                    ? "Pending"
+                    : receiptStatus === "failed"
+                      ? "Failed"
+                      : "Confirmed"}
+                </span>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

[canton-middleware#281](https://github.com/ChainSafe/canton-middleware/pull/281) made `eth_sendRawTransaction` async — the API now returns the tx hash before the Canton transfer settles. Without UI changes that produced two regressions:

- **Transfer Done step** claimed "Transfer confirmed on Canton Network." immediately, even though confirmation was still seconds away.
- **Activity tab** showed nothing for the in-flight tx because `eth_getLogs` has no Transfer log until the miner seals the entry.

This PR reconciles both pages with the new async flow.

## What changed

- **`lib/pendingTxs.ts` (new)** — localStorage-backed store keyed by user address. Records outgoing transfers between submission and receipt. JSON-safe (`amount` stored as decimal string, not bigint).
- **`lib/ethrpc.ts:getTransactionReceipt`** — wraps `eth_getTransactionReceipt`; returns `null` while still pending. Surfaces the non-standard `revertReason` field for status=0 receipts so we can show the Canton-side error.
- **Transfer page (`pages/TransferPage.tsx`)**
  - After every submit (custodial + non-custodial), records the tx in the pending store.
  - Done step polls the receipt every 3s while pending:
    - Pending: amber circle + spinner, *"Awaiting confirmation on Canton Network…"*, Status row reads "Pending".
    - Success: existing teal check, *"Transfer confirmed on Canton Network."*, Status "Confirmed".
    - Failed: red circle + ✕, subtitle shows `revertReason` (falls back to "Reverted on Canton Network."), Status "Failed".
- **Activity tab (`pages/DashboardActivityPage.tsx`)**
  - Merges pending entries on top of confirmed logs (de-duplicated by tx hash; confirmed wins). Pending entries land in a dedicated `PENDING` day-group with a pulsing amber pill in the TYPE cell.
  - Failed entries stay visible with a red `Failed` pill and the revert reason as a tooltip.
  - Polls receipts every 4s for unresolved entries; on success drops the entry (the confirmed log appears on the next refetch), on failure marks it failed.
  - Reconciles localStorage on every log fetch: any pending entry whose confirmed log just arrived is pruned (covers reloads and missed polls).

## Notes / follow-ups (intentionally out of scope)

- Failed entries persist in localStorage with no UI to dismiss. Worth a small "✕" affordance once we see how this lands.
- No max age / TTL on pending entries — a tx that gets stuck forever would sit in the list. Tied to the same circuit-breaker follow-up flagged on the API side.
- Multiple browser tabs each poll independently. Could dedupe with `BroadcastChannel`; not worth it for now.

## Test plan

- [x] `npx tsc --noEmit` (dapp)
- [x] `npm run lint` (dapp)
- [x] `npm run build` (dapp)
- [ ] Manual (non-custodial): submit a transfer, observe Done step shows pending spinner + "Awaiting confirmation"; Activity tab shows a PENDING row at the top with the amber pill; both transition to confirmed within a few seconds.
- [ ] Manual (custodial): same flow via MetaMask `eth_sendTransaction`.
- [ ] Manual (failed tx — e.g. insufficient balance): observe red ✕ on Done step with revert reason, and red `Failed` pill on Activity row with reason as tooltip.
- [ ] Manual: refresh the dapp while a tx is pending; pending row reappears from localStorage, polling resumes, resolves correctly.
- [ ] Manual: submit a transfer, navigate to Activity before the receipt lands; pending row visible and resolves in place.