### PR TITLE
licensing: add Apache 2.0 (LICENSE, NOTICE, SPDX headers)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,55 @@
+canton-snap
+Copyright 2026 ChainSafe Systems, Inc.
+
+This product includes software developed by ChainSafe Systems, Inc.
+(https://chainsafe.io).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+================================================================================
+Third-Party Software
+================================================================================
+
+This product depends on third-party software with the following licenses. The
+full text of each license is available in the upstream repository of each
+dependency.
+
+--------------------------------------------------------------------------------
+@metamask/snaps-sdk
+Copyright (c) Consensys Software Inc.
+License: ISC
+
+--------------------------------------------------------------------------------
+@metamask/key-tree
+Copyright (c) Consensys Software Inc.
+License: ISC
+
+--------------------------------------------------------------------------------
+@noble/curves, @noble/hashes
+Copyright (c) 2022 Paul Miller (https://paulmillr.com).
+License: MIT
+
+--------------------------------------------------------------------------------
+React (react, react-dom)
+Copyright (c) Meta Platforms, Inc. and affiliates.
+License: MIT
+
+--------------------------------------------------------------------------------
+Vite
+Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors.
+License: MIT
+
+--------------------------------------------------------------------------------
+
+For the complete list of transitive dependencies and their licenses, see the
+upstream package.json of each dependency.

--- a/README.md
+++ b/README.md
@@ -169,3 +169,10 @@ await window.ethereum.request({
 ```
 
 Check install status with `wallet_getSnaps`.
+
+## License
+
+This project is licensed under the Apache License, Version 2.0. See
+[LICENSE](LICENSE) for the full license text and [NOTICE](NOTICE) for
+attributions of third-party software included in or depended on by this
+project.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "description": "MetaMask Snap for non-custodial Canton Network signing",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "workspaces": [
     "packages/snap",
     "packages/dapp"

--- a/packages/dapp/eslint.config.js
+++ b/packages/dapp/eslint.config.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import js from '@eslint/js';
 import ts from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -26,5 +26,6 @@
     "vite": "^6.3.0",
     "vitest": "^3.2.4"
   },
-  "notes": "Run 'npm install' in this directory to set up the build toolchain before development."
+  "notes": "Run 'npm install' in this directory to set up the build toolchain before development.",
+  "license": "Apache-2.0"
 }

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useCallback, useEffect } from "react";
 import { useMetaMask } from "./hooks/useMetaMask";
 import { useRegistration } from "./hooks/useRegistration";

--- a/packages/dapp/src/components/AmbientOrb.tsx
+++ b/packages/dapp/src/components/AmbientOrb.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 interface AmbientOrbProps {
   color?: string;
   opacity?: number;

--- a/packages/dapp/src/components/Button.tsx
+++ b/packages/dapp/src/components/Button.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { type ReactNode, type ButtonHTMLAttributes } from "react";
 
 type Variant = "primary" | "primary-sm" | "secondary" | "ghost" | "danger";

--- a/packages/dapp/src/components/CopyButton.tsx
+++ b/packages/dapp/src/components/CopyButton.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState } from "react";
 
 interface CopyButtonProps {

--- a/packages/dapp/src/components/DashboardLayout.tsx
+++ b/packages/dapp/src/components/DashboardLayout.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useRef, useEffect, type ReactNode } from "react";
 import { Logo } from "./Logo";
 import { WalletMenu } from "./WalletMenu";

--- a/packages/dapp/src/components/Logo.tsx
+++ b/packages/dapp/src/components/Logo.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export function Logo() {
   return (
     <svg width="32" height="32" viewBox="0 0 32 32" fill="none">

--- a/packages/dapp/src/components/PageCard.tsx
+++ b/packages/dapp/src/components/PageCard.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ReactNode } from "react";
 import { cn } from "../lib/cn";
 import styles from "./PageCard.module.css";

--- a/packages/dapp/src/components/Spinner.tsx
+++ b/packages/dapp/src/components/Spinner.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 interface SpinnerProps {
   size?: number;
   color?: string;

--- a/packages/dapp/src/components/TopBar.tsx
+++ b/packages/dapp/src/components/TopBar.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useRef, useEffect } from "react";
 import { Logo } from "./Logo";
 import { WalletMenu } from "./WalletMenu";

--- a/packages/dapp/src/components/WalletMenu.tsx
+++ b/packages/dapp/src/components/WalletMenu.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { CopyButton } from "./CopyButton";
 import { shortenAddress } from "../lib/ethereum";
 import styles from "./WalletMenu.module.css";

--- a/packages/dapp/src/hooks/useAutoNetworkSwitch.ts
+++ b/packages/dapp/src/hooks/useAutoNetworkSwitch.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useRef } from "react";
 import { ensureChainAdded } from "../lib/network";
 import type { NetworkConfig } from "../lib/config";

--- a/packages/dapp/src/hooks/useMetaMask.ts
+++ b/packages/dapp/src/hooks/useMetaMask.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useCallback, useEffect } from "react";
 import { requestAccounts, getAccounts } from "../lib/ethereum";
 

--- a/packages/dapp/src/hooks/useMetaMaskImport.ts
+++ b/packages/dapp/src/hooks/useMetaMaskImport.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useEffect, useState } from "react";
 import { watchAsset } from "../lib/ethereum";
 import { ensureChainAdded } from "../lib/network";

--- a/packages/dapp/src/hooks/useRegistration.ts
+++ b/packages/dapp/src/hooks/useRegistration.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useCallback } from "react";
 import { personalSign } from "../lib/ethereum";
 import {

--- a/packages/dapp/src/hooks/useSnap.ts
+++ b/packages/dapp/src/hooks/useSnap.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useEffect, useCallback } from "react";
 import { installSnap, getInstalledSnap, invokeSnap } from "../lib/ethereum";
 import { NON_CUSTODIAL_ENABLED } from "../lib/features";

--- a/packages/dapp/src/lib/cn.ts
+++ b/packages/dapp/src/lib/cn.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export function cn(...classes: (string | undefined | false | null)[]): string {
   return classes.filter(Boolean).join(" ");
 }

--- a/packages/dapp/src/lib/config.ts
+++ b/packages/dapp/src/lib/config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export interface NativeCurrency {
   name: string;
   symbol: string;

--- a/packages/dapp/src/lib/ethereum.ts
+++ b/packages/dapp/src/lib/ethereum.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { getAddress } from "ethers";
 
 const PUBLISHED_SNAP_ID = "npm:@chainsafe/canton-snap";

--- a/packages/dapp/src/lib/ethrpc.ts
+++ b/packages/dapp/src/lib/ethrpc.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 let _rpcId = 0;
 
 const ERC20_TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";

--- a/packages/dapp/src/lib/features.ts
+++ b/packages/dapp/src/lib/features.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Build-time feature flags. Read from Vite env so each deployment can opt in
  * without rebuilding the source.

--- a/packages/dapp/src/lib/middleware.ts
+++ b/packages/dapp/src/lib/middleware.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export interface TokenConfig {
   address: string;
   name: string;

--- a/packages/dapp/src/lib/network.ts
+++ b/packages/dapp/src/lib/network.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { addEthChain, getEthereum, switchEthChain } from "./ethereum";
 import { ethChainId } from "./ethrpc";
 import type { NetworkConfig } from "./config";

--- a/packages/dapp/src/lib/session.ts
+++ b/packages/dapp/src/lib/session.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 const SESSION_PREFIX = "canton_session_";
 
 export interface Session {

--- a/packages/dapp/src/lib/tokens.ts
+++ b/packages/dapp/src/lib/tokens.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export const TOKEN_COLORS: Record<string, { bg: string; text: string }> = {
   DEMO: { bg: "#00d4a4", text: "#0a0b14" },
   PROMPT: { bg: "#8b7cff", text: "#0a0b14" },

--- a/packages/dapp/src/lib/transfer.ts
+++ b/packages/dapp/src/lib/transfer.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { personalSign } from "./ethereum";
 import { friendlyError } from "./middleware";
 

--- a/packages/dapp/src/main.tsx
+++ b/packages/dapp/src/main.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";

--- a/packages/dapp/src/pages/CustodialRegistrationPage.tsx
+++ b/packages/dapp/src/pages/CustodialRegistrationPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useRef, useState } from "react";
 import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useEffect, useMemo } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";

--- a/packages/dapp/src/pages/DashboardBalancesPage.tsx
+++ b/packages/dapp/src/pages/DashboardBalancesPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useEffect, useCallback } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useEffect } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { CopyButton } from "../components/CopyButton";

--- a/packages/dapp/src/pages/LandingPage.tsx
+++ b/packages/dapp/src/pages/LandingPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { Button } from "../components/Button";

--- a/packages/dapp/src/pages/NonCustodialRegistrationPage.tsx
+++ b/packages/dapp/src/pages/NonCustodialRegistrationPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { Button } from "../components/Button";

--- a/packages/dapp/src/pages/RegistrationChoicePage.tsx
+++ b/packages/dapp/src/pages/RegistrationChoicePage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { Button } from "../components/Button";

--- a/packages/dapp/src/pages/RegistrationDonePage.tsx
+++ b/packages/dapp/src/pages/RegistrationDonePage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { Button } from "../components/Button";

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useEffect, useRef } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";

--- a/packages/dapp/src/vite-env.d.ts
+++ b/packages/dapp/src/vite-env.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {

--- a/packages/dapp/vite.config.ts
+++ b/packages/dapp/vite.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/ChainSafe/canton-snap.git",
     "directory": "packages/snap"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "ChainSafe Systems",
   "main": "dist/bundle.js",
   "files": [

--- a/packages/snap/snap.config.ts
+++ b/packages/snap/snap.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import type { SnapConfig } from "@metamask/snaps-cli";
 import { config as loadEnv } from "dotenv";
 import { resolve } from "path";

--- a/packages/snap/src/dialogs.ts
+++ b/packages/snap/src/dialogs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Confirmation dialog builders for Canton Snap.
  *

--- a/packages/snap/src/fingerprint.ts
+++ b/packages/snap/src/fingerprint.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Canton key fingerprint computation.
  *

--- a/packages/snap/src/hex.ts
+++ b/packages/snap/src/hex.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Hex utilities shared by every input-parsing path in the snap.
  *

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Canton Snap — MetaMask Snap for non-custodial Canton Network signing.
  */

--- a/packages/snap/src/keyDerivation.ts
+++ b/packages/snap/src/keyDerivation.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Key derivation for Canton signing keys using snap_getEntropy.
  *

--- a/packages/snap/src/origin.ts
+++ b/packages/snap/src/origin.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Origin gating for signing methods.
  *

--- a/packages/snap/src/sign.ts
+++ b/packages/snap/src/sign.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * DER-encoded ECDSA signing for Canton Interactive Submission.
  *

--- a/packages/snap/src/spki.ts
+++ b/packages/snap/src/spki.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * SPKI DER encoding for secp256k1 public keys.
  *

--- a/packages/snap/src/state.ts
+++ b/packages/snap/src/state.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Persistent snap state.
  *

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export interface GetPublicKeyParams {
   keyIndex?: number;
 }

--- a/packages/snap/src/validation.ts
+++ b/packages/snap/src/validation.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * RPC parameter validation. Runs before any dialog or key derivation so
  * malformed input is rejected without paying the cost of rendering

--- a/packages/snap/test/crypto.test.ts
+++ b/packages/snap/test/crypto.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Cross-validation tests against Go-generated test vectors.
  *

--- a/packages/snap/test/index.test.js
+++ b/packages/snap/test/index.test.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { installSnap } from "@metamask/snaps-jest";
 
 const validHash = "ab".repeat(32);

--- a/packages/snap/test/origin.test.ts
+++ b/packages/snap/test/origin.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { assertSigningOrigin } from "../src/origin.js";
 

--- a/packages/snap/test/setup.js
+++ b/packages/snap/test/setup.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Polyfill globalThis.crypto for the snaps-jest simulation environment.
 // The real MetaMask Snap runtime provides crypto natively, but the
 // test simulator (snaps-jest) does not include it by default.

--- a/packages/snap/test/validation.test.ts
+++ b/packages/snap/test/validation.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import {
   validateKeyIndex,

--- a/packages/snap/vitest.config.ts
+++ b/packages/snap/vitest.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Brings the canton-snap repo into Apache 2.0 compliance: adds the
missing root `LICENSE` file, adds a `NOTICE` enumerating bundled
third-party software, switches all three workspace `package.json`
files from MIT (or unset) to Apache-2.0, adds SPDX headers to all 56
first-party TypeScript/TSX/JS files, and adds a License section to the
README.

This is one of several parallel PRs supporting the licensing posture
committed to in the upcoming CIP56/ERC-20 Middleware grant proposal.

### Commits in this PR

1. `licensing: add root LICENSE (Apache 2.0) and NOTICE` — verbatim
   Apache 2.0 license text plus a NOTICE enumerating MetaMask Snaps
   SDK, key-tree, @noble/curves, @noble/hashes, React, and Vite.
2. `licensing: add SPDX headers to TypeScript and JavaScript source` —
   56 first-party `.ts`/`.tsx`/`.js` files across `packages/snap` and
   `packages/dapp`. `node_modules`, `dist`, `build`, and `.snap`
   output directories are intentionally skipped.
3. `licensing: set package.json license fields to Apache-2.0` — root
   workspace and both packages flipped from MIT (or unset) to
   Apache-2.0.
4. `licensing: add License section to README`.

## Test plan

- [ ] `npm install` from root still resolves cleanly.
- [ ] `npm run build` (or equivalent in each package) still succeeds.
- [ ] `npm test` still passes.
- [ ] Snap loads in MetaMask Flask against a local dapp build.