### PR TITLE
fix(dapp): rename product to EVM Middleware + landing copy

### DIFF
--- a/packages/dapp/index.html
+++ b/packages/dapp/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Canton Snap Test dApp</title>
+    <title>EVM Middleware</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/dapp/src/components/DashboardLayout.tsx
+++ b/packages/dapp/src/components/DashboardLayout.tsx
@@ -119,7 +119,7 @@ export function DashboardLayout({
           <div className="topbar-logo-icon">
             <Logo />
           </div>
-          <span className="topbar-logo-text">Canton dApp</span>
+          <span className="topbar-logo-text">EVM Middleware</span>
         </div>
         <div className={styles.sidebarDivider} />
         <nav className={styles.sidebarNav}>

--- a/packages/dapp/src/components/TopBar.tsx
+++ b/packages/dapp/src/components/TopBar.tsx
@@ -44,7 +44,7 @@ export function TopBar({ address, onDisconnect }: Props) {
         <div className="topbar-logo-icon">
           <Logo />
         </div>
-        <span className="topbar-logo-text">Canton dApp</span>
+        <span className="topbar-logo-text">EVM Middleware</span>
       </div>
 
       {address && (

--- a/packages/dapp/src/pages/LandingPage.tsx
+++ b/packages/dapp/src/pages/LandingPage.tsx
@@ -26,7 +26,7 @@ export function LandingPage({ connecting, error, detected, onConnect }: Props) {
 
         <p className={styles.subtitle}>
           Register a Canton party, hold tokens, and transfer —<br />
-          all with MetaMask you already have.
+          all with your existing MetaMask.
         </p>
 
         {!detected && (


### PR DESCRIPTION
## Summary
Branding pass ahead of production (closes #69).

- Renames the logo text from `Canton dApp` → **`EVM Middleware`** in the dashboard sidebar (`DashboardLayout.tsx`) and the landing top bar (`TopBar.tsx`). We must not name the product after Canton (regulatory).
- Updates the browser tab title `Canton Snap Test dApp` → **`EVM Middleware`** (`index.html`).
- Reword landing subtitle: `all with MetaMask you already have.` → **`all with your existing MetaMask.`** (`LandingPage.tsx`).

## Notes / follow-ups for production
- Eyebrow/heading copy still references "Canton" descriptively ("Canton for EVM users", "Use Canton like Ethereum") — that's describing the *network*, not the product name, so left as-is. Flag if legal wants those changed too.
- A proper logo/favicon is still a separate task.

## Test
- `npm run lint` / `npm run build` in `packages/dapp`.
- Visual: sidebar + landing show "EVM Middleware"; tab title updated.

Closes #69