### PR TITLE
fix(dapp): activity timestamps in local time, not UTC

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b8586f35-35cb-4ee2-a80e-3ac683758a43","pid":63405,"procStart":"Tue Jun  2 07:04:56 2026","acquiredAt":1780481630395}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b8586f35-35cb-4ee2-a80e-3ac683758a43","pid":63405,"procStart":"Tue Jun  2 07:04:56 2026","acquiredAt":1780481630395}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_Store
 .env
 .env.local
+
+# Claude Code local files
+.claude/

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -80,12 +80,14 @@ function relativeTime(ts: number): string {
   return `${Math.floor(diff / 86400)}d ago`;
 }
 
-function timeUTC(ts: number): string {
+function timeLocal(ts: number): string {
   if (!ts || ts < MIN_REAL_TIMESTAMP) return "";
+  // Render in the viewer's local timezone (timeZoneName shows the local
+  // abbreviation, e.g. EDT/GMT+1). Day grouping below also uses local time,
+  // so the time shown stays consistent with its day label.
   return new Date(ts * 1000).toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
-    timeZone: "UTC",
     timeZoneName: "short",
   });
 }
@@ -472,7 +474,7 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
                               : isFailed
                                 ? "Reverted"
                                 : row.timestamp >= MIN_REAL_TIMESTAMP
-                                  ? timeUTC(row.timestamp)
+                                  ? timeLocal(row.timestamp)
                                   : `Block #${row.blockNumber}`}
                           </span>
                         </div>

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -86,7 +86,7 @@ function timeLocal(ts: number): string {
   // abbreviation, e.g. EDT/GMT+1). Day grouping below also uses local time,
   // so the time shown stays consistent with its day label.
   return new Date(ts * 1000).toLocaleTimeString("en-US", {
-    hour: "2-digit",
+    hour: "numeric",
     minute: "2-digit",
     timeZoneName: "short",
   });


### PR DESCRIPTION
## Summary
Activity tab timestamps were rendered with a hard-coded `timeZone: "UTC"`, while the day-group labels (TODAY / YESTERDAY / weekday) already use local time. On non-UTC machines the time could therefore disagree with its own day label. This renders the time in the viewer's **local** timezone (with the local tz abbreviation still shown via `timeZoneName: "short"`).

- `DashboardActivityPage.tsx`: `timeUTC` → `timeLocal`, drop `timeZone: "UTC"`.

## Test
- `npm run lint` / `npm run build` in `packages/dapp`.
- Visual: a confirmed transfer's time matches local wall-clock and its day group.

Closes #67