### PR TITLE
fix(dapp): responsive layout for mobile viewports

### DIFF
--- a/packages/dapp/src/components/DashboardLayout.module.css
+++ b/packages/dapp/src/components/DashboardLayout.module.css
@@ -98,3 +98,56 @@
 .pillAnchor {
   position: relative;
 }
+
+/* ── Mobile: stack the fixed-width sidebar above the content as a top bar,
+   with the nav laid out as a horizontal, scrollable tab strip. ── */
+@media (max-width: 768px) {
+  .layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-shrink: 0;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .sidebarLogo {
+    padding: 16px 20px 10px;
+  }
+
+  .sidebarDivider {
+    display: none;
+  }
+
+  .sidebarNav {
+    flex-direction: row;
+    padding: 0 12px 8px;
+    gap: 4px;
+    overflow-x: auto;
+  }
+
+  .navItem {
+    width: auto;
+    flex-shrink: 0;
+    height: 36px;
+    padding: 0 14px;
+    gap: 10px;
+  }
+
+  /* The active-state left accent bar is a vertical-nav affordance; drop it
+     in the horizontal strip where the pill background already marks active. */
+  .navItemActive::before {
+    display: none;
+  }
+
+  .main {
+    padding: 16px 20px 32px;
+  }
+
+  .mainHeader {
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+  }
+}

--- a/packages/dapp/src/hooks/useMediaQuery.ts
+++ b/packages/dapp/src/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribe to a CSS media query and re-render when it starts/stops matching.
+ * Mirrors the breakpoints used in the stylesheets so JS-driven UI (e.g. value
+ * truncation) stays in sync with the CSS layout.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/packages/dapp/src/index.css
+++ b/packages/dapp/src/index.css
@@ -523,13 +523,17 @@ body {
 }
 
 /* ── Mobile: tighten the generous desktop side padding on the top bar and
-   fixed footer so content isn't pushed off-screen on small viewports. ── */
+   footer so content isn't pushed off-screen on small viewports. The footer
+   also drops its desktop fixed positioning — on a short viewport a fixed
+   footer overlaps the landing CTA/links; static lets it sit at the end of
+   the flex-column flow instead. ── */
 @media (max-width: 768px) {
   .topbar {
     padding: 16px 20px;
   }
 
   .footer {
+    position: static;
     padding: 16px 20px;
     gap: 12px;
   }

--- a/packages/dapp/src/index.css
+++ b/packages/dapp/src/index.css
@@ -521,3 +521,16 @@ body {
   filter: blur(24px);
   pointer-events: none;
 }
+
+/* ── Mobile: tighten the generous desktop side padding on the top bar and
+   fixed footer so content isn't pushed off-screen on small viewports. ── */
+@media (max-width: 768px) {
+  .topbar {
+    padding: 16px 20px;
+  }
+
+  .footer {
+    padding: 16px 20px;
+    gap: 12px;
+  }
+}

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -57,8 +57,11 @@
 /* ── Column headers (above card) ── */
 .colHeaders {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  column-gap: 32px;
+  /* Content-weighted tracks: TX HASH / TO-FROM are the widest, TYPE/TOKEN/
+     AMOUNT/DATE are narrower. Equal 1fr columns starved the hash columns and
+     made the rows overlap until ~1500px wide. Must match .activityRow. */
+  grid-template-columns: 0.95fr 0.7fr 0.85fr 1.15fr 1.35fr 0.9fr;
+  column-gap: 20px;
   padding: 0 24px 12px;
   font-size: 11px;
   font-weight: 600;
@@ -98,8 +101,8 @@
 
 .activityRow {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  column-gap: 32px;
+  grid-template-columns: 0.95fr 0.7fr 0.85fr 1.15fr 1.35fr 0.9fr;
+  column-gap: 20px;
   align-items: center;
   padding: 16px 24px;
 }
@@ -109,6 +112,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
 }
 
 .typeIcon {
@@ -196,6 +200,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .tokenIcon {
@@ -236,6 +241,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .addrValue {
@@ -243,6 +249,8 @@
   font-size: 12px;
   color: var(--text-secondary);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 
@@ -252,12 +260,14 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 3px;
+  min-width: 0;
 }
 
 .amountValue {
   font-family: var(--font-mono);
   font-size: 14px;
   font-weight: 700;
+  white-space: nowrap;
 }
 
 .amountSent {
@@ -279,16 +289,19 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 3px;
+  min-width: 0;
 }
 
 .whenRelative {
   font-size: 12px;
   color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .whenAbsolute {
   font-size: 11px;
   color: var(--text-muted);
+  white-space: nowrap;
 }
 
 /* Loading / error / empty */
@@ -325,9 +338,11 @@
   color: var(--text-muted);
 }
 
-/* ── Mobile: the 6-column table can't fit a phone, so hide the column
-   header and reflow each row into a compact 2-column card. ── */
-@media (max-width: 768px) {
+/* ── Tablet + mobile: the 6-column table needs a wide viewport, but the 240px
+   sidebar keeps the content area narrow well past the 768px nav breakpoint, so
+   the table overlaps on a tablet. Reflow into a compact 2-column card at 1024px
+   (the table only has room above that). ── */
+@media (max-width: 1024px) {
   .pageHeader {
     flex-direction: column;
     align-items: stretch;
@@ -377,5 +392,49 @@
 
   .rowDivider {
     margin: 0 16px;
+  }
+}
+
+/* ── Phone: tighten spacing and put TO/FROM and TX side by side (row 3) so
+   each transaction takes 3 rows instead of 4. ── */
+@media (max-width: 560px) {
+  .activityRow {
+    padding: 13px 14px;
+    row-gap: 9px;
+    column-gap: 12px;
+  }
+
+  .typeIcon {
+    width: 28px;
+    height: 28px;
+  }
+
+  .tokenIcon {
+    width: 24px;
+    height: 24px;
+  }
+
+  /* Cells render in DOM order: type, token, amount, addr(to/from), addr(tx),
+     when. The 4th/5th cells are the two addr blocks — sit them side by side. */
+  .addrCell {
+    grid-column: auto;
+  }
+
+  .activityRow > div:nth-child(4) {
+    grid-column: 1;
+    grid-row: 3;
+  }
+
+  .activityRow > div:nth-child(5) {
+    grid-column: 2;
+    grid-row: 3;
+  }
+
+  .addrValue {
+    font-size: 11px;
+  }
+
+  .rowDivider {
+    margin: 0 14px;
   }
 }

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -324,3 +324,58 @@
   font-size: 12px;
   color: var(--text-muted);
 }
+
+/* ── Mobile: the 6-column table can't fit a phone, so hide the column
+   header and reflow each row into a compact 2-column card. ── */
+@media (max-width: 768px) {
+  .pageHeader {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 14px;
+  }
+
+  .searchBar {
+    width: 100%;
+  }
+
+  .colHeaders {
+    display: none;
+  }
+
+  .activityRow {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 16px;
+    row-gap: 12px;
+    padding: 16px;
+  }
+
+  /* Row 1: type ┊ date — Row 2: token ┊ amount — Rows 3-4: to/from + tx full-width */
+  .typeCell {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .whenCell {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .tokenCell {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .amountCell {
+    grid-column: 2;
+    grid-row: 2;
+    align-items: flex-end;
+  }
+
+  .addrCell {
+    grid-column: 1 / -1;
+  }
+
+  .rowDivider {
+    margin: 0 16px;
+  }
+}

--- a/packages/dapp/src/pages/DashboardBalancesPage.module.css
+++ b/packages/dapp/src/pages/DashboardBalancesPage.module.css
@@ -276,3 +276,19 @@
   color: var(--amber);
   padding: 0 0 10px;
 }
+
+/* ── Mobile: the fixed 160px balance column crowds out the token name on a
+   phone — let balance and action size to content so the name keeps the
+   flexible track, and tighten the gaps. ── */
+@media (max-width: 560px) {
+  .colHeaders,
+  .tokenRow {
+    grid-template-columns: 1fr auto auto;
+    gap: 14px;
+  }
+
+  .card,
+  .offersCard {
+    padding: 0 16px;
+  }
+}

--- a/packages/dapp/src/pages/DashboardBalancesPage.module.css
+++ b/packages/dapp/src/pages/DashboardBalancesPage.module.css
@@ -278,12 +278,14 @@
 }
 
 /* ── Mobile: the fixed 160px balance column crowds out the token name on a
-   phone — let balance and action size to content so the name keeps the
-   flexible track, and tighten the gaps. ── */
+   phone. Narrow the balance/action columns so the name keeps the flexible
+   track, and tighten the gaps. Keep them fixed (not auto) so the header and
+   every row stay vertically aligned and the empty header span doesn't
+   collapse to 0. ── */
 @media (max-width: 560px) {
   .colHeaders,
   .tokenRow {
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr 110px 80px;
     gap: 14px;
   }
 

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -234,10 +234,21 @@
   cursor: not-allowed;
 }
 
-/* ── Mobile: the identity card's 1fr/300px split and the 3-up connection grid
-   don't fit a phone, and the 32px card padding eats the narrow width. Stack
-   everything into a single column and tighten the padding/gaps. Matches the
-   768px breakpoint where DashboardLayout switches to the top-nav strip. ── */
+/* ── Stack the identity card's party / quick-actions split into one column. ──
+   The two-column split only has room when the content area is wide. With the
+   240px sidebar + 48px main padding still present above the 768px nav
+   breakpoint, the party column gets crushed (~140px) on a tablet, so this
+   collapses at 1024px rather than 768px. */
+@media (max-width: 1024px) {
+  .identityCard {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 28px;
+  }
+}
+
+/* ── Mobile: tighten the 32px card padding that eats the narrow width and
+   trim heading/connection spacing. Matches the 768px breakpoint where
+   DashboardLayout switches to the top-nav strip. ── */
 @media (max-width: 768px) {
   .pageSubtitle {
     margin-bottom: 24px;
@@ -246,11 +257,6 @@
   .identityCard,
   .connectionCard {
     padding: 24px;
-  }
-
-  .identityCard {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 28px;
   }
 
   .connectionGrid {

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -22,9 +22,16 @@
   /* Quick-actions track scales with the viewport (instead of a fixed 300px
      that holds its size then snaps to full-width) so the Send button shrinks
      gradually as the window narrows, down to the 768px stack breakpoint. */
-  grid-template-columns: 1fr clamp(200px, 26%, 300px);
+  grid-template-columns: minmax(0, 1fr) clamp(200px, 26%, 300px);
   gap: clamp(24px, 4vw, 48px);
   margin-bottom: 24px;
+}
+
+/* Grid tracks default to min-width:auto, which would grow to fit the
+   non-wrapping MidTruncate hash (defeating its ellipsis and overflowing the
+   card). Let the cells shrink below their content instead. */
+.identityCard > div {
+  min-width: 0;
 }
 
 .sectionLabel {
@@ -242,7 +249,7 @@
   }
 
   .identityCard {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 28px;
   }
 

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -46,6 +46,25 @@
   margin-bottom: 28px;
 }
 
+.partyIdCol {
+  min-width: 0;
+}
+
+/* Full-width middle-ellipsis (mobile): start grows + elides, tail pinned right.
+   Inert until the parent is a flex container (set per-row at the 560px
+   breakpoint), so desktop keeps the full, wrapped value. */
+.midStart {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.midEnd {
+  flex-shrink: 0;
+}
+
 .partyId {
   font-family: var(--font-mono);
   font-size: 19px;
@@ -235,5 +254,26 @@
 @media (max-width: 560px) {
   .connectionGrid {
     grid-template-columns: 1fr;
+  }
+
+  /* Let the party-ID / fingerprint values fill the row width (so they line up
+     with the full-width action button) and push the copy button / mode tag to
+     the right edge, instead of clustering left with dead space. */
+  .partyIdCol {
+    flex: 1;
+  }
+
+  .partyIdCont {
+    display: flex;
+  }
+
+  .fingerprintRow {
+    flex-wrap: nowrap;
+  }
+
+  .fingerprint {
+    display: flex;
+    flex: 1;
+    min-width: 0;
   }
 }

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -71,6 +71,12 @@
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text-secondary);
+  /* The fingerprint is one long unbreakable hash. Without this it sets the
+     min-content width of the 1fr identity column, growing the whole card past
+     its container and pushing Quick Actions off-screen (and overflowing the
+     card on mobile). min-width:0 lets the flex item shrink so the text breaks. */
+  min-width: 0;
+  word-break: break-all;
 }
 
 /* ── Quick actions ── */
@@ -197,4 +203,34 @@
 .reinstallBtn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ── Mobile: the identity card's 1fr/300px split and the 3-up connection grid
+   don't fit a phone, and the 32px card padding eats the narrow width. Stack
+   everything into a single column and tighten the padding/gaps. Matches the
+   768px breakpoint where DashboardLayout switches to the top-nav strip. ── */
+@media (max-width: 768px) {
+  .pageSubtitle {
+    margin-bottom: 24px;
+  }
+
+  .identityCard,
+  .connectionCard {
+    padding: 24px;
+  }
+
+  .identityCard {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .connectionGrid {
+    gap: 24px;
+  }
+}
+
+@media (max-width: 560px) {
+  .connectionGrid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/packages/dapp/src/pages/DashboardProfilePage.module.css
+++ b/packages/dapp/src/pages/DashboardProfilePage.module.css
@@ -19,8 +19,11 @@
   border-radius: var(--radius-lg);
   padding: 32px;
   display: grid;
-  grid-template-columns: 1fr 300px;
-  gap: 48px;
+  /* Quick-actions track scales with the viewport (instead of a fixed 300px
+     that holds its size then snaps to full-width) so the Send button shrinks
+     gradually as the window narrows, down to the 768px stack breakpoint. */
+  grid-template-columns: 1fr clamp(200px, 26%, 300px);
+  gap: clamp(24px, 4vw, 48px);
   margin-bottom: 24px;
 }
 

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -5,6 +5,7 @@ import { AmbientOrb } from "../components/AmbientOrb";
 import { CopyButton } from "../components/CopyButton";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
 import { shortenAddress } from "../lib/ethereum";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 import { NETWORK } from "../lib/config";
 import { cn } from "../lib/cn";
 import { checkMiddlewareHealth } from "../lib/middleware";
@@ -37,6 +38,11 @@ export function DashboardProfilePage({
 
   const isNonCustodial = profile.keyMode === "external";
   const middlewareHealthy = healthCache?.url === NETWORK.middlewareUrl ? healthCache.healthy : null;
+
+  // On a phone the full party ID / fingerprint hashes wrap into an unreadable
+  // multi-line block. Show a shortened middle-ellipsis form; the copy buttons
+  // still carry the full value. Matches the 560px stack breakpoint in the CSS.
+  const isPhone = useMediaQuery("(max-width: 560px)");
 
   useEffect(() => {
     let cancelled = false;
@@ -75,7 +81,11 @@ export function DashboardProfilePage({
                   return (
                     <>
                       <p className={styles.partyId}>{head}</p>
-                      {cont && <p className={styles.partyIdCont}>{cont}</p>}
+                      {cont && (
+                        <p className={styles.partyIdCont}>
+                          {isPhone ? shortenAddress(cont, 6) : cont}
+                        </p>
+                      )}
                     </>
                   );
                 })()}
@@ -85,7 +95,11 @@ export function DashboardProfilePage({
 
             <p className={`${styles.sectionLabel} ${styles.sectionLabelTop}`}>FINGERPRINT</p>
             <div className={styles.fingerprintRow}>
-              <p className={styles.fingerprint}>{profile.fingerprint}</p>
+              <p className={styles.fingerprint}>
+                {isPhone && profile.fingerprint
+                  ? shortenAddress(profile.fingerprint, 6)
+                  : profile.fingerprint}
+              </p>
               {profile.fingerprint && <CopyButton text={profile.fingerprint} />}
               <span
                 className={cn(

--- a/packages/dapp/src/pages/DashboardProfilePage.tsx
+++ b/packages/dapp/src/pages/DashboardProfilePage.tsx
@@ -23,6 +23,21 @@ interface Props {
   onDisconnect: () => void;
 }
 
+/**
+ * Full-width middle-ellipsis for a long hash: the leading part fills the row
+ * and elides, the last `tail` chars stay pinned to the right edge. Lets the
+ * value span the same width as the card content (aligned with the action
+ * button) instead of leaving dead space, while still showing both ends.
+ */
+function MidTruncate({ value, tail = 6 }: { value: string; tail?: number }) {
+  return (
+    <>
+      <span className={styles.midStart}>{value.slice(0, -tail)}</span>
+      <span className={styles.midEnd}>{value.slice(-tail)}</span>
+    </>
+  );
+}
+
 export function DashboardProfilePage({
   address,
   profile,
@@ -72,7 +87,7 @@ export function DashboardProfilePage({
           <div>
             <p className={styles.sectionLabel}>CANTON PARTY</p>
             <div className={styles.partyIdRow}>
-              <div style={{ minWidth: 0 }}>
+              <div className={styles.partyIdCol}>
                 {(() => {
                   const sep = profile.cantonPartyId.indexOf("::");
                   const head =
@@ -83,7 +98,7 @@ export function DashboardProfilePage({
                       <p className={styles.partyId}>{head}</p>
                       {cont && (
                         <p className={styles.partyIdCont}>
-                          {isPhone ? shortenAddress(cont, 6) : cont}
+                          {isPhone ? <MidTruncate value={cont} /> : cont}
                         </p>
                       )}
                     </>
@@ -96,9 +111,11 @@ export function DashboardProfilePage({
             <p className={`${styles.sectionLabel} ${styles.sectionLabelTop}`}>FINGERPRINT</p>
             <div className={styles.fingerprintRow}>
               <p className={styles.fingerprint}>
-                {isPhone && profile.fingerprint
-                  ? shortenAddress(profile.fingerprint, 6)
-                  : profile.fingerprint}
+                {isPhone && profile.fingerprint ? (
+                  <MidTruncate value={profile.fingerprint} />
+                ) : (
+                  profile.fingerprint
+                )}
               </p>
               {profile.fingerprint && <CopyButton text={profile.fingerprint} />}
               <span

--- a/packages/dapp/src/pages/LandingPage.module.css
+++ b/packages/dapp/src/pages/LandingPage.module.css
@@ -67,3 +67,19 @@
   color: var(--text-secondary);
   text-decoration: none;
 }
+
+/* ── Mobile: shrink the hero type and let the CTA fill the column. ── */
+@media (max-width: 560px) {
+  .title {
+    font-size: 32px;
+  }
+
+  .subtitle {
+    font-size: 15px;
+  }
+
+  .cta {
+    width: 100%;
+    max-width: 360px;
+  }
+}

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -800,4 +800,18 @@
   .btnViewActivity {
     width: 100%;
   }
+
+  /* Trim the wide desktop card padding so inputs/buttons get more usable
+     width on a phone. */
+  .card {
+    padding: 24px 16px;
+  }
+
+  .signCard {
+    padding: 32px 16px 24px;
+  }
+
+  .doneCard {
+    padding: 32px 16px;
+  }
 }

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -773,3 +773,31 @@
   font-family: var(--font-sans);
   cursor: pointer;
 }
+
+/* ── Mobile: stack the receipt rows and the two fixed-width Done buttons so
+   long values and the 280px buttons don't overflow a phone. ── */
+@media (max-width: 560px) {
+  .pageHeader {
+    flex-wrap: wrap;
+  }
+
+  .receiptRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .receiptValue {
+    text-align: left;
+    max-width: 100%;
+  }
+
+  .doneActions {
+    flex-direction: column;
+  }
+
+  .btnSendAnother,
+  .btnViewActivity {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
The dapp had **no media queries at all**, so the desktop layout (fixed 240px sidebar, rigid 6-column activity table, 280px buttons, wide paddings) broke on phones. This adds a coherent responsive pass (closes #68).

### Changes (CSS-only)
- **Shell** (`DashboardLayout.module.css`, `index.css`): at ≤768px the sidebar stacks above content as a top bar with a horizontal, scrollable nav strip; top-bar/footer/main paddings tightened.
- **Activity** (`DashboardActivityPage.module.css`): ≤768px hides the 6-col header and reflows each row into a 2-col card (type ┊ date / token ┊ amount / to-from / tx); search goes full-width.
- **Balances** (`DashboardBalancesPage.module.css`): ≤560px sizes the balance + action columns to content so the token name keeps the flexible track.
- **Transfer** (`TransferPage.module.css`): ≤560px stacks receipt rows and the two 280px Done buttons full-width.
- **Landing** (`LandingPage.module.css`): ≤560px smaller hero type, full-width CTA.

Breakpoints: 768px (tablet/shell) and 560px (phone).

## Test
- `npm run build` ✅ (`packages/dapp`).
- Recommend a visual pass in devtools device mode (375px / 414px) across all tabs.

## Scope / follow-ups
- Profile page relies on existing flex + `word-break`, so it benefits from the shell changes without dedicated rules; worth a visual check.
- A real logo/favicon and any deeper component polish are out of scope here.

Closes #68