### PR TITLE
feat(dapp): one-click "Add tokens to MetaMask" after registration + balances banner

### DIFF
--- a/packages/dapp/src/components/ImportTokensBanner.module.css
+++ b/packages/dapp/src/components/ImportTokensBanner.module.css
@@ -1,0 +1,189 @@
+/* Shared "Add tokens to MetaMask" surface — banner (balances) + card (post-registration).
+   Vertical layout: header (icon + copy) → footer (token preview + action). Scales to
+   any token count via an overlapping-avatar stack that collapses into a "+N" badge. */
+
+.root {
+  position: relative;
+  z-index: 1;
+  /* Match the design-system .card (border + radius + gradient) so this reads
+     as the same family as the party-ID card and the balances card. */
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--bg-card);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* Banner: aligned to the same 768px content column as the balances PageCard
+   (and section headers), with a gap below before the balances card. */
+.banner {
+  max-width: 768px;
+  margin-left: max(0px, calc(50% - 432px));
+  margin-right: auto;
+  margin-bottom: 20px;
+}
+
+/* Card: matches the registration party-ID card width, with a gap above it. */
+.card {
+  width: min(560px, 100%);
+  margin: 20px auto 0;
+  text-align: left;
+}
+
+/* ── Header ── */
+.head {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.iconWrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--teal) 14%, transparent);
+  color: var(--teal);
+  flex-shrink: 0;
+}
+
+.iconWrapDone {
+  background: color-mix(in srgb, var(--green) 16%, transparent);
+  color: var(--green);
+}
+
+.copy {
+  min-width: 0;
+  flex: 1;
+  padding-top: 1px;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 3px;
+}
+
+.subtitle {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+/* ── Footer: token preview (left) + action (right) ── */
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.preview {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.avatars {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.avatar,
+.avatarMore {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 700;
+  /* Ring matches the card backdrop so overlapping avatars read as separated. */
+  box-shadow: 0 0 0 2px #14172480;
+  margin-left: -8px;
+}
+
+.avatar:first-child {
+  margin-left: 0;
+}
+
+.avatarMore {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-muted);
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.avatarBadge {
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 800;
+  box-shadow: 0 0 0 2px #141724;
+}
+
+.avatarBadgeOk {
+  background: var(--green);
+  color: #0a0b14;
+}
+
+.avatarBadgeErr {
+  background: var(--amber);
+  color: #0a0b14;
+}
+
+.avatarSpinner {
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  border: 2px solid rgba(10, 11, 20, 0.25);
+  border-top-color: #0a0b14;
+  animation: importAvatarSpin 0.7s linear infinite;
+}
+
+@keyframes importAvatarSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.previewLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.action {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* When the row can't fit both items (narrow viewport or the card variant),
+   the action drops to its own full-width line below the preview. */
+.card .action {
+  flex: 1 1 100%;
+}
+
+@media (max-width: 560px) {
+  .action {
+    flex: 1 1 100%;
+  }
+}

--- a/packages/dapp/src/components/ImportTokensBanner.tsx
+++ b/packages/dapp/src/components/ImportTokensBanner.tsx
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from "react";
+import { Button } from "./Button";
+import { Spinner } from "./Spinner";
+import { NETWORK } from "../lib/config";
+import type { NetworkConfig } from "../lib/config";
+import { getTokens, type TokenConfig } from "../lib/middleware";
+import { TOKEN_COLORS } from "../lib/tokens";
+import { useMetaMaskImport, type TokenImportState } from "../hooks/useMetaMaskImport";
+import { cn } from "../lib/cn";
+import styles from "./ImportTokensBanner.module.css";
+
+// How many token avatars to show before collapsing the rest into a "+N" badge.
+// Keeps the preview compact no matter how many tokens the network exposes.
+const MAX_AVATARS = 5;
+
+function WalletPlusIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <rect x="2.5" y="5" width="15" height="11" rx="2" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M2.5 9H17.5" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M14 11.5V14M12.75 12.75H15.25"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path
+        d="M2.5 7.5L5.5 10.5L11.5 3.5"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function statusFor(token: TokenConfig, states: Record<string, TokenImportState>) {
+  return states[token.address]?.status ?? "idle";
+}
+
+function TokenAvatar({
+  token,
+  status,
+  index,
+}: {
+  token: TokenConfig;
+  status: TokenImportState["status"];
+  index: number;
+}) {
+  const colors = TOKEN_COLORS[token.symbol.toUpperCase()] ?? { bg: "#656a8a", text: "#ffffff" };
+  return (
+    <span
+      className={styles.avatar}
+      // Stack later avatars beneath earlier ones so the overlap reads left-to-right.
+      style={{ background: colors.bg, color: colors.text, zIndex: MAX_AVATARS - index }}
+      title={
+        status === "success"
+          ? `${token.symbol} — added`
+          : status === "error"
+            ? `${token.symbol} — not added`
+            : token.symbol
+      }
+    >
+      {token.symbol.charAt(0).toUpperCase()}
+      {status === "pending" && <span className={styles.avatarSpinner} />}
+      {status === "success" && (
+        <span className={cn(styles.avatarBadge, styles.avatarBadgeOk)}>
+          <CheckIcon size={9} />
+        </span>
+      )}
+      {status === "error" && <span className={cn(styles.avatarBadge, styles.avatarBadgeErr)}>!</span>}
+    </span>
+  );
+}
+
+/**
+ * Presentational "Add your tokens to MetaMask" surface. Rendered as a full-width
+ * `banner` (atop the balances list) or a centred `card` (after registration).
+ * State is driven entirely by props so a parent that already owns a
+ * useMetaMaskImport instance (the balances page) stays the single source of
+ * truth — see MetaMaskImportPanel for the self-contained variant.
+ */
+export function ImportTokensBanner({
+  variant,
+  tokens,
+  tokenStates,
+  importingAll,
+  onImportAll,
+}: {
+  variant: "banner" | "card";
+  tokens: TokenConfig[];
+  tokenStates: Record<string, TokenImportState>;
+  importingAll: boolean;
+  onImportAll: () => void;
+}) {
+  if (tokens.length === 0) return null;
+
+  const total = tokens.length;
+  const importedCount = tokens.filter((t) => statusFor(t, tokenStates) === "success").length;
+  const remaining = total - importedCount;
+  const allImported = remaining === 0;
+
+  const visible = tokens.slice(0, MAX_AVATARS);
+  const overflow = total - visible.length;
+
+  const buttonLabel = importingAll
+    ? `Adding… ${importedCount}/${total}`
+    : importedCount > 0
+      ? `Add ${remaining} more`
+      : total === 1
+        ? "Add to MetaMask"
+        : `Add all ${total} to MetaMask`;
+
+  const statusLabel = allImported
+    ? `All ${total} ${total === 1 ? "token" : "tokens"} added`
+    : importedCount > 0
+      ? `${importedCount} of ${total} added`
+      : `${total} ${total === 1 ? "token" : "tokens"}`;
+
+  return (
+    <div className={cn(styles.root, variant === "card" ? styles.card : styles.banner)}>
+      <div className={styles.head}>
+        <div className={cn(styles.iconWrap, allImported && styles.iconWrapDone)}>
+          {allImported ? <CheckIcon size={18} /> : <WalletPlusIcon />}
+        </div>
+        <div className={styles.copy}>
+          <p className={styles.title}>
+            {allImported ? "Your tokens are in MetaMask" : "Add your tokens to MetaMask"}
+          </p>
+          <p className={styles.subtitle}>
+            {allImported
+              ? "View and send these tokens directly from your wallet."
+              : "Import them so balances and transfers show in MetaMask."}
+          </p>
+        </div>
+      </div>
+
+      <div className={styles.foot}>
+        <div className={styles.preview}>
+          <div className={styles.avatars}>
+            {visible.map((token, i) => (
+              <TokenAvatar
+                key={token.address}
+                token={token}
+                status={statusFor(token, tokenStates)}
+                index={i}
+              />
+            ))}
+            {overflow > 0 && <span className={styles.avatarMore}>+{overflow}</span>}
+          </div>
+          <span className={styles.previewLabel}>{statusLabel}</span>
+        </div>
+
+        {!allImported && (
+          <Button
+            variant="primary"
+            onClick={onImportAll}
+            disabled={importingAll}
+            className={styles.action}
+          >
+            {importingAll && <Spinner size={14} color="#0a0b14" />}
+            {buttonLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Self-contained variant: fetches the token list and owns its own
+ * useMetaMaskImport instance. Use this where there's no existing import state to
+ * share (e.g. the post-registration screen). Renders nothing until at least one
+ * token is known.
+ */
+export function MetaMaskImportPanel({
+  address,
+  variant = "card",
+  network = NETWORK,
+}: {
+  address: string;
+  variant?: "banner" | "card";
+  network?: NetworkConfig;
+}) {
+  const [tokens, setTokens] = useState<TokenConfig[]>([]);
+  const { tokenStates, importAll, importingAll } = useMetaMaskImport(network, address);
+
+  useEffect(() => {
+    let cancelled = false;
+    getTokens(network.middlewareUrl)
+      .then((items) => {
+        if (!cancelled) setTokens(items);
+      })
+      .catch(() => {
+        // No tokens to import (or middleware unreachable) — render nothing.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network.middlewareUrl]);
+
+  if (tokens.length === 0) return null;
+
+  return (
+    <ImportTokensBanner
+      variant={variant}
+      tokens={tokens}
+      tokenStates={tokenStates}
+      importingAll={importingAll}
+      onImportAll={() => void importAll(tokens)}
+    />
+  );
+}

--- a/packages/dapp/src/components/ImportTokensBanner.tsx
+++ b/packages/dapp/src/components/ImportTokensBanner.tsx
@@ -78,7 +78,9 @@ function TokenAvatar({
           <CheckIcon size={9} />
         </span>
       )}
-      {status === "error" && <span className={cn(styles.avatarBadge, styles.avatarBadgeErr)}>!</span>}
+      {status === "error" && (
+        <span className={cn(styles.avatarBadge, styles.avatarBadgeErr)}>!</span>
+      )}
     </span>
   );
 }

--- a/packages/dapp/src/hooks/useMetaMaskImport.ts
+++ b/packages/dapp/src/hooks/useMetaMaskImport.ts
@@ -76,6 +76,7 @@ function formatError(err: unknown): string {
 
 export function useMetaMaskImport(network: NetworkConfig, address: string) {
   const [state, setState] = useState<State>(() => hydrate(address, network.id));
+  const [importingAll, setImportingAll] = useState(false);
 
   // Re-hydrate when the account or network changes.
   useEffect(() => {
@@ -83,7 +84,11 @@ export function useMetaMaskImport(network: NetworkConfig, address: string) {
   }, [address, network.id]);
 
   const importToken = useCallback(
-    async (token: TokenConfig): Promise<boolean> => {
+    // `skipEnsureChain` lets importAll switch the chain once up front and then
+    // fire the per-token suggestions concurrently — without each call racing to
+    // re-check/switch the chain, which would stagger the watchAsset requests and
+    // defeat MetaMask's batching (see importAll).
+    async (token: TokenConfig, opts?: { skipEnsureChain?: boolean }): Promise<boolean> => {
       const persisted = loadPersisted(address, network.id);
       const wasAlreadyImported = persisted.has(token.address);
 
@@ -92,7 +97,7 @@ export function useMetaMaskImport(network: NetworkConfig, address: string) {
       }));
 
       try {
-        await ensureChainAdded(network);
+        if (!opts?.skipEnsureChain) await ensureChainAdded(network);
         const added = await watchAsset({
           address: token.address,
           symbol: token.symbol,
@@ -100,8 +105,14 @@ export function useMetaMaskImport(network: NetworkConfig, address: string) {
         });
 
         if (added) {
-          persisted.add(token.address);
-          savePersisted(address, network.id, persisted);
+          // Re-read the latest set at write time, then union. importAll fires
+          // several imports concurrently (one batched MetaMask prompt); each
+          // success handler must merge onto the others' writes rather than
+          // overwrite from the snapshot taken before the prompt — otherwise the
+          // last writer wins and only one token ends up persisted.
+          const latest = loadPersisted(address, network.id);
+          latest.add(token.address);
+          savePersisted(address, network.id, latest);
           setState((s) => ({
             tokens: { ...s.tokens, [token.address]: { status: "success" } },
           }));
@@ -143,8 +154,56 @@ export function useMetaMaskImport(network: NetworkConfig, address: string) {
     [address, network],
   );
 
+  // Import every token in one click — and in ONE MetaMask prompt. MetaMask
+  // aggregates wallet_watchAsset requests that are pending simultaneously into a
+  // single "add suggested tokens" screen listing every token. So we switch the
+  // chain once up front (its own prompt), then fire all the suggestions
+  // concurrently (skipEnsureChain so they aren't staggered by per-token chain
+  // checks). Awaiting them sequentially — as a naive loop would — keeps only one
+  // pending at a time and produces one popup per token instead.
+  const importAll = useCallback(
+    async (tokens: TokenConfig[]): Promise<void> => {
+      if (!address || tokens.length === 0) return;
+      setImportingAll(true);
+      try {
+        // Switch the chain once up front. Only skip the per-token chain check
+        // (which enables the concurrent/batched prompt) if this succeeded — on
+        // failure we let each importToken ensure the chain itself, trading the
+        // single-prompt batching for correctness.
+        let chainReady = false;
+        try {
+          await ensureChainAdded(network);
+          chainReady = true;
+        } catch {
+          // chainReady stays false — importToken will ensure the chain per token.
+        }
+
+        const persisted = loadPersisted(address, network.id);
+        const pending = tokens.filter((t) => !persisted.has(t.address));
+        const already = tokens.filter((t) => persisted.has(t.address));
+
+        // Reflect already-imported tokens as ✓ without re-prompting for them.
+        if (already.length > 0) {
+          setState((s) => ({
+            tokens: {
+              ...s.tokens,
+              ...Object.fromEntries(already.map((t) => [t.address, { status: "success" as const }])),
+            },
+          }));
+        }
+
+        await Promise.all(pending.map((t) => importToken(t, { skipEnsureChain: chainReady })));
+      } finally {
+        setImportingAll(false);
+      }
+    },
+    [address, network, importToken],
+  );
+
   return {
     tokenStates: state.tokens,
     importToken,
+    importAll,
+    importingAll,
   };
 }

--- a/packages/dapp/src/hooks/useMetaMaskImport.ts
+++ b/packages/dapp/src/hooks/useMetaMaskImport.ts
@@ -166,16 +166,15 @@ export function useMetaMaskImport(network: NetworkConfig, address: string) {
       if (!address || tokens.length === 0) return;
       setImportingAll(true);
       try {
-        // Switch the chain once up front. Only skip the per-token chain check
-        // (which enables the concurrent/batched prompt) if this succeeded — on
-        // failure we let each importToken ensure the chain itself, trading the
-        // single-prompt batching for correctness.
-        let chainReady = false;
+        // Switch the chain once up front. If this fails (e.g. the user rejects
+        // the switch), abort — we can't add tokens to the wrong chain, and
+        // continuing would fire a concurrent chain-switch prompt per token.
+        // Succeeding here lets us pass skipEnsureChain to every importToken so
+        // the watchAsset requests fire together and MetaMask batches them.
         try {
           await ensureChainAdded(network);
-          chainReady = true;
         } catch {
-          // chainReady stays false — importToken will ensure the chain per token.
+          return;
         }
 
         const persisted = loadPersisted(address, network.id);
@@ -187,12 +186,14 @@ export function useMetaMaskImport(network: NetworkConfig, address: string) {
           setState((s) => ({
             tokens: {
               ...s.tokens,
-              ...Object.fromEntries(already.map((t) => [t.address, { status: "success" as const }])),
+              ...Object.fromEntries(
+                already.map((t) => [t.address, { status: "success" as const }]),
+              ),
             },
           }));
         }
 
-        await Promise.all(pending.map((t) => importToken(t, { skipEnsureChain: chainReady })));
+        await Promise.all(pending.map((t) => importToken(t, { skipEnsureChain: true })));
       } finally {
         setImportingAll(false);
       }

--- a/packages/dapp/src/pages/DashboardBalancesPage.tsx
+++ b/packages/dapp/src/pages/DashboardBalancesPage.tsx
@@ -10,6 +10,7 @@ import { getTokens, type TokenConfig } from "../lib/middleware";
 import { getTokenBalance, formatTokenAmount } from "../lib/ethrpc";
 import { TOKEN_COLORS } from "../lib/tokens";
 import { useMetaMaskImport, type ImportStatus } from "../hooks/useMetaMaskImport";
+import { ImportTokensBanner } from "../components/ImportTokensBanner";
 import { useSnap } from "../hooks/useSnap";
 import {
   listIncomingTransfers,
@@ -55,18 +56,23 @@ function TokenIcon({ symbol }: { symbol: string }) {
   );
 }
 
-/** Wallet outline with a "+" — signals "add token". */
-function WalletPlusIcon() {
+/** MetaMask fox — signals "add this token to MetaMask". */
+function MetaMaskFoxIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-      <rect x="2.5" y="5" width="15" height="11" rx="2" stroke="currentColor" strokeWidth="1.4" />
-      <path d="M2.5 9H17.5" stroke="currentColor" strokeWidth="1.4" />
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      {/* ears */}
+      <path d="M4 2.5 L10 6.5 L7.5 8 Z" fill="#E2761B" />
+      <path d="M20 2.5 L14 6.5 L16.5 8 Z" fill="#E2761B" />
+      {/* head */}
       <path
-        d="M14 11.5V14M12.75 12.75H15.25"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
+        d="M7.5 8 L10 6.5 H14 L16.5 8 L18 13.5 L15.5 17 L12 18.5 L8.5 17 L6 13.5 Z"
+        fill="#F6851B"
       />
+      {/* muzzle */}
+      <path d="M8.5 17 L12 18.5 L15.5 17 L14 14.6 H10 Z" fill="#F8E4D0" />
+      {/* eyes */}
+      <circle cx="10" cy="11.8" r="1.05" fill="#23262E" />
+      <circle cx="14" cy="11.8" r="1.05" fill="#23262E" />
     </svg>
   );
 }
@@ -159,7 +165,7 @@ function AddTokenIconButton({
       aria-label={`Add ${symbol} to MetaMask`}
       title={`Add ${symbol} to MetaMask`}
     >
-      <WalletPlusIcon />
+      <MetaMaskFoxIcon />
     </button>
   );
 }
@@ -304,6 +310,15 @@ export function DashboardBalancesPage({
   const offerItems = offers?.items ?? null;
   const hasOffers = !!offerItems && offerItems.length > 0;
 
+  // "Add to MetaMask" banner — shown until every listed token is marked
+  // imported. MetaMask exposes no way to query already-watched assets, so this
+  // relies on the hook's best-effort localStorage mirror; if nothing is known
+  // yet, the banner stays visible.
+  const tokenList = fetchState?.rows?.map((r) => r.token) ?? [];
+  const allImported =
+    tokenList.length > 0 &&
+    tokenList.every((t) => mmImport.tokenStates[t.address]?.status === "success");
+
   return (
     <>
       <AmbientOrb opacity={0.1} size={880} x="80%" y="33%" />
@@ -313,6 +328,17 @@ export function DashboardBalancesPage({
         onTabChange={onTabChange}
         onDisconnect={onDisconnect}
       >
+        {/* ── Add tokens to MetaMask (until all imported) ── */}
+        {!loading && !allImported && tokenList.length > 0 && (
+          <ImportTokensBanner
+            variant="banner"
+            tokens={tokenList}
+            tokenStates={mmImport.tokenStates}
+            importingAll={mmImport.importingAll}
+            onImportAll={() => void mmImport.importAll(tokenList)}
+          />
+        )}
+
         {/* ── Pending offers (non-custodial, only when present) ── */}
         {isNonCustodial && hasOffers && offerItems && (
           <>

--- a/packages/dapp/src/pages/RegistrationDonePage.tsx
+++ b/packages/dapp/src/pages/RegistrationDonePage.tsx
@@ -4,6 +4,7 @@ import { TopBar } from "../components/TopBar";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { Button } from "../components/Button";
 import { CopyButton } from "../components/CopyButton";
+import { MetaMaskImportPanel } from "../components/ImportTokensBanner";
 import { cn } from "../lib/cn";
 import styles from "./RegistrationDonePage.module.css";
 
@@ -82,6 +83,8 @@ export function RegistrationDonePage({
             </div>
           </div>
         )}
+
+        <MetaMaskImportPanel address={address} variant="card" />
 
         <Button className={styles.cta} onClick={onDashboard}>
           Go to dashboard →


### PR DESCRIPTION
## Summary

Makes importing Canton tokens into MetaMask obvious and low-friction, so users — especially custodial ones who only need the dApp for registration — can operate from their wallet afterward.

## What's included

- **Post-registration card** — a prominent "Add your tokens to MetaMask" card on the registration-done screen, width-matched to the party-ID card.
- **Balances banner** — a banner at the top of the Balances tab, shown until every listed token is imported and auto-hidden once done.
- **One MetaMask prompt** — `importAll` fires `wallet_watchAsset` requests concurrently so MetaMask aggregates them into a single "add suggested tokens" screen, instead of one popup per token. The chain is switched once up front; the import aborts if that switch fails.
- **Shared `ImportTokensBanner` component** (`card` + `banner` variants) — an overlapping token-avatar stack that collapses to `+N` so it scales to any token count, with per-token status and aggregate progress.
- **MetaMask fox icon** — replaces the generic wallet glyph on each Balances row.

## Verification

- `tsc -b`, `eslint`, `prettier --check`, and `vite build` all pass.