### PR TITLE
feat(dapp): transfer by Canton party id with offer expiry

### DIFF
--- a/packages/dapp/.env.example
+++ b/packages/dapp/.env.example
@@ -12,3 +12,8 @@ VITE_MIDDLEWARE_URL=https://middleware-api-dev1.01.chainsafe.dev
 # registration skips the choice screen and goes straight to custodial). Set
 # to "true" to re-enable the registration choice and the snap-backed flow.
 # VITE_ENABLE_NON_CUSTODIAL=true
+
+# Offer-based tokens (comma-separated symbols). Transfers of these tokens create
+# an offer the recipient must accept, so the Transfer form shows an "Offer
+# expiry" field; all other tokens settle directly and hide it. Defaults to USDCX.
+# VITE_OFFER_EXPIRY_TOKENS=USDCX

--- a/packages/dapp/.env.example
+++ b/packages/dapp/.env.example
@@ -12,8 +12,3 @@ VITE_MIDDLEWARE_URL=https://middleware-api-dev1.01.chainsafe.dev
 # registration skips the choice screen and goes straight to custodial). Set
 # to "true" to re-enable the registration choice and the snap-backed flow.
 # VITE_ENABLE_NON_CUSTODIAL=true
-
-# Offer-based tokens (comma-separated symbols). Transfers of these tokens create
-# an offer the recipient must accept, so the Transfer form shows an "Offer
-# expiry" field; all other tokens settle directly and hide it. Defaults to USDCX.
-# VITE_OFFER_EXPIRY_TOKENS=USDCX

--- a/packages/dapp/src/lib/config.ts
+++ b/packages/dapp/src/lib/config.ts
@@ -50,3 +50,19 @@ export const NETWORK: NetworkConfig = {
   middlewareUrl,
   nativeCurrency: CANTON_NATIVE_CURRENCY,
 };
+
+// Tokens whose transfers are offer-based: the recipient must accept, so the
+// sender sets an offer validity (expiry) and can reclaim it if it lapses.
+// Everything else settles directly, so the Transfer UI hides the expiry field
+// for those. Configurable via VITE_OFFER_EXPIRY_TOKENS (comma-separated
+// symbols); defaults to USDCX, the only offer-based token today.
+const OFFER_EXPIRY_TOKENS: ReadonlySet<string> = new Set(
+  (import.meta.env.VITE_OFFER_EXPIRY_TOKENS ?? "USDCX")
+    .split(",")
+    .map((s: string) => s.trim().toUpperCase())
+    .filter(Boolean),
+);
+
+export function isOfferBasedToken(symbol: string | undefined): boolean {
+  return symbol !== undefined && OFFER_EXPIRY_TOKENS.has(symbol.toUpperCase());
+}

--- a/packages/dapp/src/lib/config.ts
+++ b/packages/dapp/src/lib/config.ts
@@ -54,15 +54,14 @@ export const NETWORK: NetworkConfig = {
 // Tokens whose transfers are offer-based: the recipient must accept, so the
 // sender sets an offer validity (expiry) and can reclaim it if it lapses.
 // Everything else settles directly, so the Transfer UI hides the expiry field
-// for those. Configurable via VITE_OFFER_EXPIRY_TOKENS (comma-separated
-// symbols); defaults to USDCX, the only offer-based token today.
-const OFFER_EXPIRY_TOKENS: ReadonlySet<string> = new Set(
-  (import.meta.env.VITE_OFFER_EXPIRY_TOKENS ?? "USDCX")
-    .split(",")
-    .map((s: string) => s.trim().toUpperCase())
-    .filter(Boolean),
+// for those. USDCx is the only offer-based token today — add symbols here as
+// more are introduced.
+const OFFER_BASED_TOKENS: readonly string[] = ["USDCX"];
+
+const OFFER_BASED_TOKEN_SET: ReadonlySet<string> = new Set(
+  OFFER_BASED_TOKENS.map((s) => s.toUpperCase()),
 );
 
 export function isOfferBasedToken(symbol: string | undefined): boolean {
-  return symbol !== undefined && OFFER_EXPIRY_TOKENS.has(symbol.toUpperCase());
+  return symbol !== undefined && OFFER_BASED_TOKEN_SET.has(symbol.toUpperCase());
 }

--- a/packages/dapp/src/lib/transfer.ts
+++ b/packages/dapp/src/lib/transfer.ts
@@ -73,8 +73,7 @@ export async function prepareTransfer(
   const authHeaders = await makeAuthHeaders(address);
   // The middleware accepts exactly one of `to` (EVM address) or `to_party_id`
   // (Canton party id); `validity_seconds` is mandatory (canton-middleware#334).
-  const recipientField =
-    recipientType === "party" ? { to_party_id: recipient } : { to: recipient };
+  const recipientField = recipientType === "party" ? { to_party_id: recipient } : { to: recipient };
   const res = await fetch(`${baseUrl}/api/v2/transfer/prepare`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders },

--- a/packages/dapp/src/lib/transfer.ts
+++ b/packages/dapp/src/lib/transfer.ts
@@ -10,6 +10,30 @@ export interface PrepareResult {
   expiresAt: string;
 }
 
+// How the recipient field is interpreted. `address` → a registered user's EVM
+// address (`to`); `party` → an arbitrary Canton party id (`to_party_id`), which
+// may live on an external participant. The middleware requires exactly one of
+// the two, so the dapp sends whichever matches the chosen type.
+export type RecipientType = "address" | "party";
+
+// Offer validity presets surfaced in the Transfer UI. The chosen value is sent
+// as `validity_seconds`: how long the recipient has to accept before the offer
+// expires on-ledger and the funds become reclaimable by the sender.
+export interface ValidityPreset {
+  label: string;
+  seconds: number;
+}
+
+export const VALIDITY_PRESETS: readonly ValidityPreset[] = [
+  { label: "1 hour", seconds: 3600 },
+  { label: "6 hours", seconds: 21600 },
+  { label: "1 day", seconds: 86400 },
+  { label: "1 week", seconds: 604800 },
+];
+
+// Default offer validity (1 day) — used when the caller doesn't specify one.
+export const DEFAULT_VALIDITY_SECONDS = 86400;
+
 // Server-truncated party identifiers (e.g. `user_2dA…4680b7ec`). The endpoint
 // is unauthenticated, so the middleware redacts the fingerprint portion of the
 // party id; the truncated form is sufficient for the dapp to disambiguate
@@ -40,15 +64,21 @@ async function makeAuthHeaders(
 export async function prepareTransfer(
   baseUrl: string,
   address: string,
-  to: string,
+  recipient: string,
   token: string,
   amount: string,
+  recipientType: RecipientType = "address",
+  validitySeconds: number = DEFAULT_VALIDITY_SECONDS,
 ): Promise<PrepareResult> {
   const authHeaders = await makeAuthHeaders(address);
+  // The middleware accepts exactly one of `to` (EVM address) or `to_party_id`
+  // (Canton party id); `validity_seconds` is mandatory (canton-middleware#334).
+  const recipientField =
+    recipientType === "party" ? { to_party_id: recipient } : { to: recipient };
   const res = await fetch(`${baseUrl}/api/v2/transfer/prepare`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders },
-    body: JSON.stringify({ to, amount, token }),
+    body: JSON.stringify({ ...recipientField, amount, token, validity_seconds: validitySeconds }),
   });
   if (!res.ok) throw new Error(friendlyError(res.status, await res.text()));
   const data = await res.json();
@@ -72,6 +102,33 @@ export async function executeTransfer(
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders },
     body: JSON.stringify({ transfer_id: transferId, signature, signed_by: signedBy }),
+  });
+  if (!res.ok) throw new Error(friendlyError(res.status, await res.text()));
+}
+
+// Custodial single-call transfer to a Canton party id. The middleware holds the
+// custodial user's Canton key and signs server-side, so prepare + execute happen
+// in one request — there's no hash for the dapp to sign and no snap involved.
+// Settles directly (the recipient still accepts if they're external). Custodial
+// transfers to a plain EVM address keep using the existing ERC-20 path.
+export async function sendCustodialTransfer(
+  baseUrl: string,
+  address: string,
+  toPartyId: string,
+  token: string,
+  amount: string,
+  validitySeconds: number = DEFAULT_VALIDITY_SECONDS,
+): Promise<void> {
+  const authHeaders = await makeAuthHeaders(address);
+  const res = await fetch(`${baseUrl}/api/v2/transfer/custodial`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders },
+    body: JSON.stringify({
+      to_party_id: toPartyId,
+      amount,
+      token,
+      validity_seconds: validitySeconds,
+    }),
   });
   if (!res.ok) throw new Error(friendlyError(res.status, await res.text()));
 }

--- a/packages/dapp/src/pages/TransferPage.module.css
+++ b/packages/dapp/src/pages/TransferPage.module.css
@@ -148,6 +148,170 @@
   margin-bottom: 16px;
 }
 
+/* ── Recipient type toggle (EVM Address / Canton Party ID) ── */
+.rtypeGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.rtypeOption {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 13px 15px;
+  border-radius: 12px;
+  border: 1px solid #353a5a;
+  background: #1a1d2e;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.rtypeOption:hover {
+  border-color: #43496e;
+}
+
+.rtypeOptionSelected {
+  border-color: var(--teal);
+  background: rgba(0, 212, 164, 0.07);
+}
+
+.rtypeIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a0b14;
+  border: 1px solid var(--border);
+}
+
+.rtypeOptionSelected .rtypeIcon {
+  border-color: rgba(0, 212, 164, 0.4);
+}
+
+.rtypeText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.rtypeTitle {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rtypeDesc {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.rtypeRadio {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1.5px solid #353a5a;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.rtypeRadioSelected {
+  border-color: var(--teal);
+  background: radial-gradient(circle, var(--teal) 0 5px, transparent 6px);
+}
+
+/* ── Offer expiry chips + custom value ── */
+.expiryRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.expiryChip {
+  flex: 1;
+  min-width: 72px;
+  height: 44px;
+  border-radius: 10px;
+  border: 1px solid #353a5a;
+  background: #1a1d2e;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    color 0.15s;
+}
+
+.expiryChip:hover {
+  border-color: #43496e;
+  color: var(--text-primary);
+}
+
+.expiryChipSelected {
+  border-color: var(--teal);
+  background: rgba(0, 212, 164, 0.07);
+  color: var(--teal);
+}
+
+.expiryCustomRow {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.expiryCustomInput {
+  flex: 1;
+  min-width: 0;
+  height: 48px;
+  background: #1a1d2e;
+  border: 1px solid #353a5a;
+  border-radius: 10px;
+  padding: 0 14px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.expiryCustomInput:focus {
+  outline: none;
+  border-color: var(--teal);
+}
+
+.expiryCustomInput::placeholder {
+  color: #353a5a;
+}
+
+.expiryCustomUnit {
+  height: 48px;
+  background: #1a1d2e;
+  border: 1px solid #353a5a;
+  border-radius: 10px;
+  padding: 0 12px;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.expiryCustomUnit:focus {
+  outline: none;
+  border-color: var(--teal);
+}
+
 /* ── Token dropdown ── */
 .tokenDropdownWrapper {
   position: relative;
@@ -779,6 +943,10 @@
 @media (max-width: 560px) {
   .pageHeader {
     flex-wrap: wrap;
+  }
+
+  .rtypeGrid {
+    grid-template-columns: 1fr;
   }
 
   .receiptRow {

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -5,7 +5,7 @@ import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
 import { PageCard } from "../components/PageCard";
 import { Spinner } from "../components/Spinner";
-import { NETWORK } from "../lib/config";
+import { NETWORK, isOfferBasedToken } from "../lib/config";
 import { getTokens, type TokenConfig } from "../lib/middleware";
 import {
   getTokenBalance,
@@ -769,12 +769,13 @@ export function TransferPage({
   const selectedBalance = selectedToken ? balances.get(selectedToken.address) : undefined;
   const pillClass = isNonCustodial ? styles.modePillNonCustodial : styles.modePillCustodial;
 
-  // Custodial sends to a plain EVM address settle via a raw ERC-20 transfer and
-  // carry no offer validity. Every other path (any non-custodial send, or a
-  // custodial send to a party id) goes through the middleware and needs a
-  // validity, so the Offer expiry control is shown for those.
+  // Offer expiry only applies to offer-based tokens (e.g. USDCx, configurable):
+  // the recipient must accept, so there's an offer that can expire. Other tokens
+  // settle directly with no offer. Custodial sends to a plain EVM address also
+  // settle directly (raw ERC-20), so they never carry a validity either.
+  const offerBased = isOfferBasedToken(selectedToken?.symbol);
   const isCustodialParty = !isNonCustodial && recipientType === "party";
-  const usesValidity = isNonCustodial || isCustodialParty;
+  const usesValidity = offerBased && (isNonCustodial || isCustodialParty);
 
   return (
     <>
@@ -909,11 +910,19 @@ export function TransferPage({
             <div className={styles.infoStrip}>
               <InfoIcon />
               {isCustodialParty ? (
-                <span>
-                  Gas-free on Canton · The recipient party receives an{" "}
-                  <strong style={{ color: "var(--text-primary)" }}>offer to accept</strong> — the
-                  server co-signs on your behalf.
-                </span>
+                offerBased ? (
+                  <span>
+                    Gas-free on Canton · The recipient party receives an{" "}
+                    <strong style={{ color: "var(--text-primary)" }}>offer to accept</strong> — the
+                    server co-signs on your behalf.
+                  </span>
+                ) : (
+                  <span>
+                    Gas-free on Canton · Sent{" "}
+                    <strong style={{ color: "var(--text-primary)" }}>directly</strong> to the party
+                    — the server co-signs on your behalf.
+                  </span>
+                )
               ) : isNonCustodial ? (
                 <span>
                   Gas-free on Canton · Settles in ~2–4s · You&apos;ll sign{" "}

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -258,7 +258,7 @@ function ExpiryPicker({ value, onChange }: { value: number; onChange: (seconds: 
           <input
             className={styles.expiryCustomInput}
             type="text"
-            inputMode="numeric"
+            inputMode="decimal"
             placeholder="0"
             value={num}
             onChange={(e) => updateCustom(e.target.value.replace(/[^\d.]/g, ""), unit)}
@@ -698,6 +698,8 @@ export function TransferPage({
     setStep("details");
     setAmount("");
     setRecipient("");
+    setRecipientType("address");
+    setValiditySeconds(DEFAULT_VALIDITY_SECONDS);
     setPrepared(null);
     setSignPhase("idle");
     setError(null);

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -763,9 +763,7 @@ export function TransferPage({
   }
 
   const recipientValid =
-    recipientType === "party"
-      ? PARTY_ID_RE.test(recipient)
-      : /^0x[0-9a-fA-F]{40}$/.test(recipient);
+    recipientType === "party" ? PARTY_ID_RE.test(recipient) : /^0x[0-9a-fA-F]{40}$/.test(recipient);
   const selectedBalance = selectedToken ? balances.get(selectedToken.address) : undefined;
   const pillClass = isNonCustodial ? styles.modePillNonCustodial : styles.modePillCustodial;
 
@@ -899,7 +897,8 @@ export function TransferPage({
                 <p className={styles.fieldLabel}>OFFER EXPIRY</p>
                 <ExpiryPicker value={validitySeconds} onChange={setValiditySeconds} />
                 <p className={styles.balanceHint}>
-                  The recipient has this long to accept. After it expires the offer can be reclaimed.
+                  The recipient has this long to accept. After it expires the offer can be
+                  reclaimed.
                 </p>
               </div>
             )}
@@ -1053,7 +1052,9 @@ export function TransferPage({
             <div className={styles.contractPreview}>
               <span className={styles.contractPreviewLabel}>
                 {isCustodialParty ? "CANTON TRANSFER" : "CONTRACT CALL"}
-                <span className={styles.contractVia}>{isCustodialParty ? "via /custodial" : "via /eth"}</span>
+                <span className={styles.contractVia}>
+                  {isCustodialParty ? "via /custodial" : "via /eth"}
+                </span>
               </span>
               <span className={styles.contractCall}>
                 {isCustodialParty

--- a/packages/dapp/src/pages/TransferPage.tsx
+++ b/packages/dapp/src/pages/TransferPage.tsx
@@ -14,7 +14,15 @@ import {
   getTransactionReceipt,
   parseTokenAmount,
 } from "../lib/ethrpc";
-import { prepareTransfer, executeTransfer, type PrepareResult } from "../lib/transfer";
+import {
+  prepareTransfer,
+  executeTransfer,
+  sendCustodialTransfer,
+  VALIDITY_PRESETS,
+  DEFAULT_VALIDITY_SECONDS,
+  type PrepareResult,
+  type RecipientType,
+} from "../lib/transfer";
 import { sendEthTransaction, shortenAddress, toChecksumAddress } from "../lib/ethereum";
 import { ensureChainAdded } from "../lib/network";
 import { TOKEN_COLORS } from "../lib/tokens";
@@ -30,7 +38,9 @@ type Step = "details" | "sign" | "done";
 type SignPhase = "idle" | "preparing" | "awaiting-snap" | "signing" | "executing";
 
 interface Receipt {
-  txHash: string;
+  // Absent for custodial party-id sends, which settle server-side in one call
+  // and return no EVM transaction hash.
+  txHash?: string;
   token: TokenConfig;
   amount: string;
   to: string;
@@ -76,6 +86,199 @@ function InfoIcon() {
       <path d="M7 6V10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
       <circle cx="7" cy="4" r="0.7" fill="currentColor" />
     </svg>
+  );
+}
+
+// A Canton party id is `name::fingerprint`. Kept permissive (no whitespace, a
+// `::` separator with non-empty halves) so truncated/devstack forms pass; the
+// middleware does the authoritative resolution.
+const PARTY_ID_RE = /^\S+::\S+$/;
+
+// Compact a `name::fingerprint` party id for display (keeps the readable hint,
+// truncates the long fingerprint). Mirrors the helper on the Balances page.
+function shortenPartyId(partyId: string): string {
+  const sep = partyId.indexOf("::");
+  if (sep < 0) return partyId.length > 18 ? `${partyId.slice(0, 9)}…${partyId.slice(-6)}` : partyId;
+  const head = partyId.slice(0, sep);
+  const fp = partyId.slice(sep + 2);
+  const fpShort = fp.length > 12 ? `${fp.slice(0, 6)}…${fp.slice(-4)}` : fp;
+  return `${head}::${fpShort}`;
+}
+
+const CUSTOM_UNITS = [
+  { id: "minutes", label: "minutes", seconds: 60 },
+  { id: "hours", label: "hours", seconds: 3600 },
+  { id: "days", label: "days", seconds: 86400 },
+] as const;
+type CustomUnit = (typeof CUSTOM_UNITS)[number]["id"];
+
+const MAX_VALIDITY_SECONDS = 365 * 86400;
+
+// Validity in seconds for a custom value/unit, or NaN when the input isn't a
+// usable positive number (caught by validate() before prepare).
+function customSeconds(value: string, unit: CustomUnit): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return NaN;
+  const per = CUSTOM_UNITS.find((u) => u.id === unit)?.seconds ?? 1;
+  return Math.floor(n * per);
+}
+
+function EvmAddressIcon({ active }: { active: boolean }) {
+  const stroke = active ? "#00d4a4" : "#a1a6c4";
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M12 3L18.5 12L12 16L5.5 12L12 3Z"
+        stroke={stroke}
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.5 13.3L12 21L18.5 13.3L12 17.4L5.5 13.3Z"
+        stroke={stroke}
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function PartyIdIcon({ active }: { active: boolean }) {
+  const stroke = active ? "#00d4a4" : "#a1a6c4";
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none">
+      <circle cx="9" cy="8.5" r="3" stroke={stroke} strokeWidth="1.5" />
+      <path
+        d="M3.5 19C3.5 15.7 6 13.5 9 13.5C12 13.5 14.5 15.7 14.5 19"
+        stroke={stroke}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M16 4L17 6L19 6.3L17.6 7.7L17.9 9.7L16 8.8L14.1 9.7L14.4 7.7L13 6.3L15 6L16 4Z"
+        fill={stroke}
+        opacity={0.85}
+      />
+    </svg>
+  );
+}
+
+function RecipientTypeToggle({
+  value,
+  onChange,
+}: {
+  value: RecipientType;
+  onChange: (t: RecipientType) => void;
+}) {
+  const options: { id: RecipientType; title: string; desc: string; Icon: typeof EvmAddressIcon }[] =
+    [
+      { id: "address", title: "EVM Address", desc: "0x… 40-hex address", Icon: EvmAddressIcon },
+      { id: "party", title: "Canton Party ID", desc: "name::fingerprint", Icon: PartyIdIcon },
+    ];
+  return (
+    <div className={styles.rtypeGrid} role="radiogroup" aria-label="Recipient type">
+      {options.map(({ id, title, desc, Icon }) => {
+        const selected = value === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            className={cn(styles.rtypeOption, selected && styles.rtypeOptionSelected)}
+            onClick={() => onChange(id)}
+          >
+            <span className={styles.rtypeIcon}>
+              <Icon active={selected} />
+            </span>
+            <span className={styles.rtypeText}>
+              <span className={styles.rtypeTitle}>{title}</span>
+              <span className={styles.rtypeDesc}>{desc}</span>
+            </span>
+            <span className={cn(styles.rtypeRadio, selected && styles.rtypeRadioSelected)} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ExpiryPicker({ value, onChange }: { value: number; onChange: (seconds: number) => void }) {
+  const [custom, setCustom] = useState(false);
+  const [num, setNum] = useState("3");
+  const [unit, setUnit] = useState<CustomUnit>("days");
+
+  function selectPreset(seconds: number) {
+    setCustom(false);
+    onChange(seconds);
+  }
+
+  function selectCustom() {
+    setCustom(true);
+    onChange(customSeconds(num, unit));
+  }
+
+  function updateCustom(nextNum: string, nextUnit: CustomUnit) {
+    setNum(nextNum);
+    setUnit(nextUnit);
+    onChange(customSeconds(nextNum, nextUnit));
+  }
+
+  return (
+    <>
+      <div className={styles.expiryRow} role="radiogroup" aria-label="Offer expiry">
+        {VALIDITY_PRESETS.map(({ label, seconds }) => {
+          const selected = !custom && value === seconds;
+          return (
+            <button
+              key={seconds}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              className={cn(styles.expiryChip, selected && styles.expiryChipSelected)}
+              onClick={() => selectPreset(seconds)}
+            >
+              {label}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={custom}
+          className={cn(styles.expiryChip, custom && styles.expiryChipSelected)}
+          onClick={selectCustom}
+        >
+          Custom
+        </button>
+      </div>
+
+      {custom && (
+        <div className={styles.expiryCustomRow}>
+          <input
+            className={styles.expiryCustomInput}
+            type="text"
+            inputMode="numeric"
+            placeholder="0"
+            value={num}
+            onChange={(e) => updateCustom(e.target.value.replace(/[^\d.]/g, ""), unit)}
+            aria-label="Custom expiry amount"
+          />
+          <select
+            className={styles.expiryCustomUnit}
+            value={unit}
+            onChange={(e) => updateCustom(num, e.target.value as CustomUnit)}
+            aria-label="Custom expiry unit"
+          >
+            {CUSTOM_UNITS.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -244,7 +447,9 @@ export function TransferPage({
   const [tokensLoading, setTokensLoading] = useState(true);
   const [selectedToken, setSelectedToken] = useState<TokenConfig | null>(null);
   const [balances, setBalances] = useState<Map<string, bigint>>(new Map());
+  const [recipientType, setRecipientType] = useState<RecipientType>("address");
   const [recipient, setRecipient] = useState("");
+  const [validitySeconds, setValiditySeconds] = useState<number>(DEFAULT_VALIDITY_SECONDS);
   const [amount, setAmount] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -324,6 +529,8 @@ export function TransferPage({
           recipient,
           token.symbol,
           amount,
+          recipientType,
+          validitySeconds,
         );
         if (cancelled) return;
         setPrepared(result);
@@ -347,8 +554,17 @@ export function TransferPage({
 
   function validate(): string | null {
     if (!selectedToken) return "Select a token";
-    if (!recipient.match(/^0x[0-9a-fA-F]{40}$/)) return "Enter a valid 0x EVM address";
+    if (recipientType === "party") {
+      if (!PARTY_ID_RE.test(recipient)) return "Enter a valid Canton party id (name::fingerprint)";
+    } else if (!recipient.match(/^0x[0-9a-fA-F]{40}$/)) {
+      return "Enter a valid 0x EVM address";
+    }
     if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) return "Enter a positive amount";
+    if (usesValidity) {
+      if (!Number.isFinite(validitySeconds) || validitySeconds <= 0)
+        return "Enter a valid offer expiry";
+      if (validitySeconds > MAX_VALIDITY_SECONDS) return "Offer expiry can be at most 365 days";
+    }
     const bal = balances.get(selectedToken.address);
     if (bal !== undefined) {
       if (parseTokenAmount(amount, selectedToken.decimals) > bal)
@@ -451,6 +667,33 @@ export function TransferPage({
     }
   }
 
+  // Custodial send to a Canton party id. The middleware signs server-side and
+  // settles in one call, so there's no MetaMask tx and no eth hash to poll —
+  // the receipt is "confirmed" immediately. (Custodial sends to a plain EVM
+  // address still go through handleMetaMaskSign / the ERC-20 path above.)
+  async function handleCustodialPartySend() {
+    if (!selectedToken) return;
+    setPending(true);
+    setError(null);
+    try {
+      await sendCustodialTransfer(
+        NETWORK.middlewareUrl,
+        address,
+        recipient,
+        selectedToken.symbol,
+        amount,
+        validitySeconds,
+      );
+      setReceipt({ token: selectedToken, amount, to: recipient });
+      setReceiptStatus("success");
+      setStep("done");
+    } catch (e: unknown) {
+      setError((e as Error).message);
+    } finally {
+      setPending(false);
+    }
+  }
+
   function handleReset() {
     setStep("details");
     setAmount("");
@@ -468,19 +711,20 @@ export function TransferPage({
   // a few seconds after the hash returns. Mirrors the polling on the Activity
   // tab so the pending entry there clears in lockstep with the UI here.
   useEffect(() => {
-    if (step !== "done" || !receipt || receiptStatus !== "pending") return;
+    if (step !== "done" || !receipt?.txHash || receiptStatus !== "pending") return;
     const rpcUrl = `${NETWORK.middlewareUrl}/eth`;
+    const txHash = receipt.txHash;
     let cancelled = false;
 
     async function poll() {
       try {
-        const r = await getTransactionReceipt(rpcUrl, receipt!.txHash);
+        const r = await getTransactionReceipt(rpcUrl, txHash);
         if (cancelled || !r) return;
         if (r.status === "success") {
-          removePendingTx(address, receipt!.txHash);
+          removePendingTx(address, txHash);
           setReceiptStatus("success");
         } else {
-          markPendingFailed(address, receipt!.txHash, r.revertReason);
+          markPendingFailed(address, txHash, r.revertReason);
           setRevertReason(r.revertReason);
           setReceiptStatus("failed");
         }
@@ -499,20 +743,38 @@ export function TransferPage({
 
   async function handlePaste() {
     try {
-      const text = await navigator.clipboard.readText();
-      setRecipient(toChecksumAddress(text.trim()));
+      const text = (await navigator.clipboard.readText()).trim();
+      // Only the EVM-address form is checksummed; party ids are opaque strings.
+      setRecipient(recipientType === "party" ? text : toChecksumAddress(text));
     } catch {
       // clipboard access denied — no-op
     }
   }
 
   function handleRecipientBlur() {
-    if (recipient) setRecipient(toChecksumAddress(recipient));
+    if (recipient && recipientType === "address") setRecipient(toChecksumAddress(recipient));
   }
 
-  const recipientValid = /^0x[0-9a-fA-F]{40}$/.test(recipient);
+  function handleRecipientTypeChange(t: RecipientType) {
+    if (t === recipientType) return;
+    setRecipientType(t);
+    setRecipient("");
+    setError(null);
+  }
+
+  const recipientValid =
+    recipientType === "party"
+      ? PARTY_ID_RE.test(recipient)
+      : /^0x[0-9a-fA-F]{40}$/.test(recipient);
   const selectedBalance = selectedToken ? balances.get(selectedToken.address) : undefined;
   const pillClass = isNonCustodial ? styles.modePillNonCustodial : styles.modePillCustodial;
+
+  // Custodial sends to a plain EVM address settle via a raw ERC-20 transfer and
+  // carry no offer validity. Every other path (any non-custodial send, or a
+  // custodial send to a party id) goes through the middleware and needs a
+  // validity, so the Offer expiry control is shown for those.
+  const isCustodialParty = !isNonCustodial && recipientType === "party";
+  const usesValidity = isNonCustodial || isCustodialParty;
 
   return (
     <>
@@ -558,6 +820,14 @@ export function TransferPage({
               )}
             </div>
 
+            {/* Recipient type — EVM address or Canton party id. Both modes
+                support party id: non-custodial via prepare/execute, custodial
+                via the server-signed /custodial endpoint. */}
+            <div className={styles.fieldGroup}>
+              <p className={styles.fieldLabel}>RECIPIENT TYPE</p>
+              <RecipientTypeToggle value={recipientType} onChange={handleRecipientTypeChange} />
+            </div>
+
             {/* Recipient */}
             <div className={styles.fieldGroup}>
               <p className={styles.fieldLabel}>RECIPIENT</p>
@@ -565,7 +835,7 @@ export function TransferPage({
                 <input
                   className={styles.recipientInput}
                   type="text"
-                  placeholder="0x..."
+                  placeholder={recipientType === "party" ? "name::fingerprint" : "0x..."}
                   value={recipient}
                   onChange={(e) => setRecipient(e.target.value.trim())}
                   onBlur={handleRecipientBlur}
@@ -575,7 +845,11 @@ export function TransferPage({
                   Paste
                 </button>
               </div>
-              {recipientValid && <p className={styles.recipientHint}>✓ Valid EVM address</p>}
+              {recipientValid && (
+                <p className={styles.recipientHint}>
+                  ✓ Valid {recipientType === "party" ? "Canton party ID" : "EVM address"}
+                </p>
+              )}
             </div>
 
             {/* Amount */}
@@ -617,10 +891,29 @@ export function TransferPage({
               )}
             </div>
 
+            {/* Offer expiry — sets validity_seconds: how long the recipient has
+                to accept before the offer expires and the funds can be reclaimed.
+                Shown for every send that creates an on-ledger offer. */}
+            {usesValidity && (
+              <div className={styles.fieldGroup}>
+                <p className={styles.fieldLabel}>OFFER EXPIRY</p>
+                <ExpiryPicker value={validitySeconds} onChange={setValiditySeconds} />
+                <p className={styles.balanceHint}>
+                  The recipient has this long to accept. After it expires the offer can be reclaimed.
+                </p>
+              </div>
+            )}
+
             {/* Info strip */}
             <div className={styles.infoStrip}>
               <InfoIcon />
-              {isNonCustodial ? (
+              {isCustodialParty ? (
+                <span>
+                  Gas-free on Canton · The recipient party receives an{" "}
+                  <strong style={{ color: "var(--text-primary)" }}>offer to accept</strong> — the
+                  server co-signs on your behalf.
+                </span>
+              ) : isNonCustodial ? (
                 <span>
                   Gas-free on Canton · Settles in ~2–4s · You&apos;ll sign{" "}
                   <strong style={{ color: "var(--text-primary)" }}>three times</strong> (MetaMask
@@ -752,23 +1045,26 @@ export function TransferPage({
 
             <p className={styles.signTitle}>Confirm in MetaMask</p>
             <p className={styles.signSubtitle}>
-              Sign the ERC-20 transfer — the middleware will co-sign on Canton.
+              {isCustodialParty
+                ? "Authorise the transfer — the middleware signs and settles it on Canton on your behalf."
+                : "Sign the ERC-20 transfer — the middleware will co-sign on Canton."}
             </p>
 
             <div className={styles.contractPreview}>
               <span className={styles.contractPreviewLabel}>
-                CONTRACT CALL
-                <span className={styles.contractVia}>via /eth</span>
+                {isCustodialParty ? "CANTON TRANSFER" : "CONTRACT CALL"}
+                <span className={styles.contractVia}>{isCustodialParty ? "via /custodial" : "via /eth"}</span>
               </span>
               <span className={styles.contractCall}>
-                {selectedToken.symbol.toLowerCase()}.transfer({shortenAddress(recipient)},{" "}
-                {parseTokenAmount(amount, selectedToken.decimals).toString()})
+                {isCustodialParty
+                  ? `${amount} ${selectedToken.symbol} → ${shortenPartyId(recipient)}`
+                  : `${selectedToken.symbol.toLowerCase()}.transfer(${shortenAddress(recipient)}, ${parseTokenAmount(amount, selectedToken.decimals).toString()})`}
               </span>
             </div>
 
             <button
               className={styles.btnOpenDialog}
-              onClick={handleMetaMaskSign}
+              onClick={isCustodialParty ? handleCustodialPartySend : handleMetaMaskSign}
               disabled={pending}
             >
               {pending ? "Waiting for MetaMask…" : "Open MetaMask"}
@@ -851,10 +1147,12 @@ export function TransferPage({
                 <span className={styles.receiptLabel}>To</span>
                 <span className={styles.receiptValue}>{receipt.to}</span>
               </div>
-              <div className={styles.receiptRow}>
-                <span className={styles.receiptLabel}>Transaction</span>
-                <span className={styles.receiptValue}>{receipt.txHash}</span>
-              </div>
+              {receipt.txHash && (
+                <div className={styles.receiptRow}>
+                  <span className={styles.receiptLabel}>Transaction</span>
+                  <span className={styles.receiptValue}>{receipt.txHash}</span>
+                </div>
+              )}
               <div className={styles.receiptRow}>
                 <span className={styles.receiptLabel}>Status</span>
                 <span className={styles.receiptValue}>


### PR DESCRIPTION
## What

Adds **transfer by Canton party id** to the Transfer flow, plus a user-settable **offer expiry**. Implements #80.

A recipient-type toggle (EVM Address / Canton Party ID) lets users send to a party id (`<hint>::<fingerprint>`), including parties on an external participant. Each path is routed to the matching middleware endpoint:

| Mode × recipient | Path | Notes |
|---|---|---|
| Non-custodial · address | `POST /transfer/prepare` → snap sign → `/execute` | sends `to` |
| Non-custodial · party | `POST /transfer/prepare` → snap sign → `/execute` | sends `to_party_id` |
| Custodial · address | existing ERC-20 `transfer()` via `/eth` | unchanged |
| Custodial · party | `POST /transfer/custodial` (server-signed) | settles directly; no eth tx hash |

## Offer expiry (`validity_seconds`)

Per canton-middleware#334, `validity_seconds` is now **mandatory** on prepare and required by the custodial endpoint. For an offer-based send it's the acceptance window. Added an **Offer expiry** control — presets (1h / 6h / 1d / 1w, default 1d) plus a **Custom** value + unit (minutes / hours / days) — shown for every send that creates an on-ledger offer (all non-custodial sends, and custodial party-id sends). Validated client-side: positive, ≤ 365 days.

## Aligned to the real contract

- Sends **exactly one** of `to` / `to_party_id` (no `recipient_type` discriminator).
- Custodial party-id receipt settles immediately and renders without a transaction row (the endpoint returns `{status:"completed"}`, no eth hash).

## Self-review notes

- ⚠️ **Sequencing / breaking change:** `validity_seconds` becomes mandatory when canton-middleware#334 merges — once it does, the existing address transfer 400s without it. This PR always sends it, so it should ship in lockstep with that middleware release (or gated on the deployed version).
- Endpoints (`/transfer/prepare` with `to_party_id`, `/transfer/custodial`) depend on canton-middleware#334/#335 being deployed. Routes/shapes were taken from `pkg/transfer/http.go` + `types.go` on the middleware `main`/PR branches.
- The existing custodial-address ERC-20 path is untouched; non-party flows behave exactly as before aside from now sending `validity_seconds`.
- `tsc`, `eslint`, and `vite build` all pass. No automated transfer-flow tests exist in the dapp; verified by build + manual review. Recommend a manual pass on devnet against the merged middleware.

## Out of scope
- Listing outgoing offers (the **Offers** tab) — #81.
- Claiming back expired offers — #82 (needs a new middleware reclaim endpoint).

Implements #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
