### PR TITLE
feat(dapp): rebuild Activity on the transfer history API

### DIFF
--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -383,7 +383,7 @@ export default function App() {
     }
 
     if (dashboardTab === "activity") {
-      return <DashboardActivityPage {...sharedProps} />;
+      return <DashboardActivityPage {...sharedProps} cantonPartyId={profile.cantonPartyId} />;
     }
 
     return (

--- a/packages/dapp/src/lib/transfer.ts
+++ b/packages/dapp/src/lib/transfer.ts
@@ -255,6 +255,104 @@ export async function listOutgoingTransfers(
   return all;
 }
 
+// ── Completed transfers (Activity history) ──────────────────────────────────
+//
+// A settled transfer in the unified history, across all tokens and both
+// transfer shapes (direct CIP-56 and accepted offers). Party ids are truncated
+// server-side (the endpoint is unauthenticated). `txId` is a Canton ledger
+// update id — not an EVM tx hash, so it isn't block-explorer linkable.
+export interface CompletedTransfer {
+  contractId: string;
+  kind: string; // "direct" | "offer"
+  status: string; // "completed"
+  fromPartyId: string;
+  toPartyId: string;
+  amount: string;
+  instrumentAdmin: string;
+  instrumentId: string;
+  timestamp: string; // RFC3339
+  txId?: string;
+  symbol?: string;
+  decimals?: number;
+  name?: string;
+  contractAddress?: string;
+}
+
+export interface CompletedTransfersPage {
+  items: CompletedTransfer[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+export const COMPLETED_PAGE_LIMIT = 50;
+
+interface CompletedItemResponse {
+  contract_id: string;
+  kind: string;
+  status: string;
+  from_party_id: string;
+  to_party_id: string;
+  amount: string;
+  instrument_admin: string;
+  instrument_id: string;
+  timestamp: string;
+  tx_id?: string;
+  symbol?: string;
+  decimals?: number;
+  name?: string;
+  contract_address?: string;
+}
+
+// GET /api/v2/transfer/completed?address=&page=&limit=. Unauthenticated; returns
+// one page of settled transfers (sender + receiver) for the address. Page-based
+// so the Activity tab can "Load more" rather than buffer the whole history.
+export async function listCompletedTransfers(
+  baseUrl: string,
+  address: string,
+  page = 1,
+  limit: number = COMPLETED_PAGE_LIMIT,
+): Promise<CompletedTransfersPage> {
+  const url = new URL(`${baseUrl}/api/v2/transfer/completed`);
+  url.searchParams.set("address", address);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("limit", String(limit));
+
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(friendlyError(res.status, await res.text()));
+  const data = (await res.json()) as {
+    items?: CompletedItemResponse[];
+    total?: number;
+    page?: number;
+    limit?: number;
+    has_more?: boolean;
+  };
+
+  return {
+    items: (data.items ?? []).map((t) => ({
+      contractId: t.contract_id,
+      kind: t.kind,
+      status: t.status,
+      fromPartyId: t.from_party_id,
+      toPartyId: t.to_party_id,
+      amount: t.amount,
+      instrumentAdmin: t.instrument_admin,
+      instrumentId: t.instrument_id,
+      timestamp: t.timestamp,
+      txId: t.tx_id,
+      symbol: t.symbol,
+      decimals: t.decimals,
+      name: t.name,
+      contractAddress: t.contract_address,
+    })),
+    total: data.total ?? 0,
+    page: data.page ?? page,
+    limit: data.limit ?? limit,
+    hasMore: data.has_more ?? false,
+  };
+}
+
 export async function prepareAcceptTransfer(
   baseUrl: string,
   address: string,

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -16,12 +16,20 @@
   margin-top: 6px;
 }
 
+/* Constrain the table so it doesn't stretch across an ultrawide viewport,
+   which would balloon the flexible PARTY column into a large empty gap.
+   Left-aligned to sit under the page title. */
+.colHeaders,
+.card {
+  max-width: 960px;
+}
+
 /* ── Shared row grid (header + each row) ──
    TYPE | TOKEN | AMOUNT | PARTY (flex) | LEDGER TX | DATE */
 .colHeaders,
 .activityRow {
   display: grid;
-  grid-template-columns: 116px 96px 120px minmax(0, 1fr) 132px 132px;
+  grid-template-columns: 104px 92px 108px minmax(0, 1fr) 132px 120px;
   gap: 16px;
   align-items: center;
 }
@@ -46,6 +54,11 @@
   padding: 0 22px;
   position: relative;
   z-index: 1;
+}
+
+/* Mobile-only "Tx" label (the column header is hidden on narrow viewports). */
+.txPrefix {
+  display: none;
 }
 
 .dayGroup {
@@ -240,33 +253,63 @@
   cursor: not-allowed;
 }
 
-/* ── Mobile: drop the column headers and let each row wrap into a compact
-   two-line card (type+amount on top, party/tx/date below). ── */
-@media (max-width: 720px) {
+/* ── Tablet / mobile ──
+   Below ~1100px the sidebar collapses and the main column is too narrow for
+   six side-by-side columns, so each row reflows into a compact 2-column card:
+
+     [ Sent          ]   [   −10 ]
+     [ ◎ DEMO        ]   [ 3d ago ]
+     [ To external…       (full)  ]
+     [ Tx 1220…           (full)  ]
+*/
+@media (max-width: 1100px) {
   .colHeaders {
     display: none;
   }
 
+  .card {
+    max-width: none;
+    padding: 0 16px;
+  }
+
   .activityRow {
     grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "type amount"
+      "token date"
+      "party party"
+      "tx tx";
     gap: 6px 14px;
     padding: 12px 0;
   }
 
-  /* token + amount sit on the first row beside type; party/tx/date wrap full
-     width underneath. */
-  .inlineCell,
-  .whenCell {
-    grid-column: 1 / -1;
+  .typeCell {
+    grid-area: type;
+  }
+
+  .amountValue {
+    grid-area: amount;
+    text-align: right;
+  }
+
+  .tokenCell {
+    grid-area: token;
   }
 
   .whenCell {
-    text-align: left;
+    grid-area: date;
+    text-align: right;
   }
 
-  .card,
-  .colHeaders {
-    padding-left: 16px;
-    padding-right: 16px;
+  .partyCell {
+    grid-area: party;
+  }
+
+  .txCell {
+    grid-area: tx;
+  }
+
+  .txPrefix {
+    display: inline;
   }
 }

--- a/packages/dapp/src/pages/DashboardActivityPage.module.css
+++ b/packages/dapp/src/pages/DashboardActivityPage.module.css
@@ -1,15 +1,6 @@
 /* ── Page header ── */
 .pageHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 20px;
-}
-
-.pageTitles {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  margin-bottom: 18px;
 }
 
 .pageTitle {
@@ -22,92 +13,60 @@
 .pageSubtitle {
   font-size: 13px;
   color: var(--text-secondary);
+  margin-top: 6px;
 }
 
-/* ── Search ── */
-.searchBar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 296px;
-  height: 36px;
-  background: #12141f;
-  border: 1px solid var(--border-muted);
-  border-radius: 10px;
-  padding: 0 14px;
-  color: var(--text-muted);
-  font-size: 12px;
-  flex-shrink: 0;
-}
-
-.searchInput {
-  background: none;
-  border: none;
-  outline: none;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-family: var(--font-sans);
-  width: 100%;
-}
-
-.searchInput::placeholder {
-  color: var(--text-muted);
-}
-
-/* ── Column headers (above card) ── */
-.colHeaders {
+/* ── Shared row grid (header + each row) ──
+   TYPE | TOKEN | AMOUNT | PARTY (flex) | LEDGER TX | DATE */
+.colHeaders,
+.activityRow {
   display: grid;
-  /* Content-weighted tracks: TX HASH / TO-FROM are the widest, TYPE/TOKEN/
-     AMOUNT/DATE are narrower. Equal 1fr columns starved the hash columns and
-     made the rows overlap until ~1500px wide. Must match .activityRow. */
-  grid-template-columns: 0.95fr 0.7fr 0.85fr 1.15fr 1.35fr 0.9fr;
-  column-gap: 20px;
-  padding: 0 24px 12px;
-  font-size: 11px;
+  grid-template-columns: 116px 96px 120px minmax(0, 1fr) 132px 132px;
+  gap: 16px;
+  align-items: center;
+}
+
+.colHeaders {
+  padding: 13px 22px 10px;
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 1px;
   color: var(--text-muted);
-  text-transform: uppercase;
 }
 
 .colRight {
   text-align: right;
 }
 
-/* ── Activity card (full-width) ── */
+/* ── Card ── */
 .card {
-  background: linear-gradient(180deg, #1a1d2e 0%, #12141f 100%);
+  background: var(--bg-card, linear-gradient(180deg, #1a1d2e 0%, #12141f 100%));
   border: 1px solid var(--border);
-  border-radius: 16px;
-  overflow: hidden;
+  border-radius: var(--radius-xl);
+  padding: 0 22px;
+  position: relative;
+  z-index: 1;
 }
 
-/* ── Day group label ── */
 .dayGroup {
-  padding: 16px 24px 4px;
   font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 1.2px;
+  letter-spacing: 1px;
   color: var(--text-muted);
-  text-transform: uppercase;
+  font-weight: 700;
+  padding: 14px 0 6px;
 }
 
-/* ── Activity row ── */
+/* Compact single-line rows */
+.activityRow {
+  padding: 9px 0;
+}
+
 .rowDivider {
   height: 1px;
   background: var(--border);
-  margin: 0 24px;
 }
 
-.activityRow {
-  display: grid;
-  grid-template-columns: 0.95fr 0.7fr 0.85fr 1.15fr 1.35fr 0.9fr;
-  column-gap: 20px;
-  align-items: center;
-  padding: 16px 24px;
-}
-
-/* Type cell */
+/* Type */
 .typeCell {
   display: flex;
   align-items: center;
@@ -116,9 +75,9 @@
 }
 
 .typeIcon {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -126,20 +85,13 @@
 }
 
 .iconSent {
-  background: rgba(0, 212, 164, 0.12);
-  color: #00d4a4;
+  background: rgba(255, 107, 107, 0.12);
+  color: #ff8a8a;
 }
 
 .iconReceived {
-  background: rgba(96, 165, 250, 0.14);
-  color: #60a5fa;
-}
-
-.typeStack {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--green);
 }
 
 .typeLabel {
@@ -148,69 +100,22 @@
   color: var(--text-primary);
 }
 
-.statusPill {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  align-self: flex-start;
-  padding: 2px 8px;
-  border-radius: var(--radius-full);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.statusPillPending {
-  background: color-mix(in srgb, var(--amber) 14%, transparent);
-  color: var(--amber);
-  border: 1px solid color-mix(in srgb, var(--amber) 35%, transparent);
-}
-
-.statusPillFailed {
-  background: color-mix(in srgb, var(--red) 14%, transparent);
-  color: var(--red);
-  border: 1px solid color-mix(in srgb, var(--red) 35%, transparent);
-}
-
-.statusDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  animation: pendingPulse 1.6s ease-in-out infinite;
-}
-
-@keyframes pendingPulse {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 1; }
-}
-
-.rowPending .amountValue {
-  color: var(--amber);
-}
-
-.rowFailed .amountValue {
-  color: var(--text-muted);
-  text-decoration: line-through;
-}
-
-/* Token cell */
+/* Token */
 .tokenCell {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   min-width: 0;
 }
 
 .tokenIcon {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
   flex-shrink: 0;
 }
@@ -221,90 +126,63 @@
   color: var(--text-primary);
 }
 
-/* Address / tx cells */
-.addrCell {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
+/* Amount */
+.amountValue {
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  font-weight: 700;
 }
 
-.addrLabel {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  text-transform: uppercase;
+.amountSent {
+  color: #ff8a8a;
 }
 
-.addrRow {
+.amountReceived {
+  color: var(--green);
+}
+
+/* Party + Ledger tx — single inline line each */
+.inlineCell {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   min-width: 0;
 }
 
-.addrValue {
+.prefix {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.monoValue {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-
-/* Amount cell */
-.amountCell {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 3px;
-  min-width: 0;
-}
-
-.amountValue {
-  font-family: var(--font-mono);
-  font-size: 14px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.amountSent {
-  color: var(--text-primary);
-}
-
-.amountReceived {
-  color: #34d399;
-}
-
-.amountLabel {
-  font-size: 11px;
+.muted {
   color: var(--text-muted);
+  font-size: 12px;
 }
 
-/* When cell */
+/* Date */
 .whenCell {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 3px;
-  min-width: 0;
-}
-
-.whenRelative {
+  text-align: right;
   font-size: 12px;
   color: var(--text-secondary);
   white-space: nowrap;
 }
 
-.whenAbsolute {
-  font-size: 11px;
+.whenAbs {
   color: var(--text-muted);
-  white-space: nowrap;
+  font-family: var(--font-mono);
 }
 
-/* Loading / error / empty */
+/* ── States ── */
 .centred {
   display: flex;
   align-items: center;
@@ -322,15 +200,17 @@
   font-size: 12px;
   color: var(--text-muted);
   text-align: center;
+  padding: 20px 0;
 }
 
-/* ── Footer ── */
+/* ── Footer / pagination ── */
 .footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px;
+  padding: 14px 0;
   border-top: 1px solid var(--border);
+  margin-top: 2px;
 }
 
 .footerCount {
@@ -338,103 +218,55 @@
   color: var(--text-muted);
 }
 
-/* ── Tablet + mobile: the 6-column table needs a wide viewport, but the 240px
-   sidebar keeps the content area narrow well past the 768px nav breakpoint, so
-   the table overlaps on a tablet. Reflow into a compact 2-column card at 1024px
-   (the table only has room above that). ── */
-@media (max-width: 1024px) {
-  .pageHeader {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 14px;
-  }
+.loadMore {
+  background: #232640;
+  border: 1px solid var(--border-muted);
+  color: var(--text-primary);
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
 
-  .searchBar {
-    width: 100%;
-  }
+.loadMore:hover:not(:disabled) {
+  border-color: var(--teal);
+  color: var(--teal);
+}
 
+.loadMore:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Mobile: drop the column headers and let each row wrap into a compact
+   two-line card (type+amount on top, party/tx/date below). ── */
+@media (max-width: 720px) {
   .colHeaders {
     display: none;
   }
 
   .activityRow {
-    grid-template-columns: 1fr 1fr;
-    column-gap: 16px;
-    row-gap: 12px;
-    padding: 16px;
+    grid-template-columns: 1fr auto;
+    gap: 6px 14px;
+    padding: 12px 0;
   }
 
-  /* Row 1: type ┊ date — Row 2: token ┊ amount — Rows 3-4: to/from + tx full-width */
-  .typeCell {
-    grid-column: 1;
-    grid-row: 1;
-  }
-
+  /* token + amount sit on the first row beside type; party/tx/date wrap full
+     width underneath. */
+  .inlineCell,
   .whenCell {
-    grid-column: 2;
-    grid-row: 1;
-  }
-
-  .tokenCell {
-    grid-column: 1;
-    grid-row: 2;
-  }
-
-  .amountCell {
-    grid-column: 2;
-    grid-row: 2;
-    align-items: flex-end;
-  }
-
-  .addrCell {
     grid-column: 1 / -1;
   }
 
-  .rowDivider {
-    margin: 0 16px;
-  }
-}
-
-/* ── Phone: tighten spacing and put TO/FROM and TX side by side (row 3) so
-   each transaction takes 3 rows instead of 4. ── */
-@media (max-width: 560px) {
-  .activityRow {
-    padding: 13px 14px;
-    row-gap: 9px;
-    column-gap: 12px;
+  .whenCell {
+    text-align: left;
   }
 
-  .typeIcon {
-    width: 28px;
-    height: 28px;
-  }
-
-  .tokenIcon {
-    width: 24px;
-    height: 24px;
-  }
-
-  /* Cells render in DOM order: type, token, amount, addr(to/from), addr(tx),
-     when. The 4th/5th cells are the two addr blocks — sit them side by side. */
-  .addrCell {
-    grid-column: auto;
-  }
-
-  .activityRow > div:nth-child(4) {
-    grid-column: 1;
-    grid-row: 3;
-  }
-
-  .activityRow > div:nth-child(5) {
-    grid-column: 2;
-    grid-row: 3;
-  }
-
-  .addrValue {
-    font-size: 11px;
-  }
-
-  .rowDivider {
-    margin: 0 14px;
+  .card,
+  .colHeaders {
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -259,7 +259,9 @@ export function DashboardActivityPage({
                           <span className={cn(styles.prefix, styles.txPrefix)}>Tx</span>
                           {row.txId ? (
                             <>
-                              <span className={styles.monoValue}>{shorten(row.txId)}</span>
+                              {/* Display is clipped by CSS ellipsis; the copy
+                                  button still puts the full id on the clipboard. */}
+                              <span className={styles.monoValue}>{row.txId}</span>
                               <CopyButton text={row.txId} />
                             </>
                           ) : (
@@ -310,10 +312,6 @@ function truncateParty(partyId: string): string {
   const tail = 8;
   if (partyId.length <= head + tail + 1) return partyId;
   return partyId.slice(0, head) + "…" + partyId.slice(-tail);
-}
-
-function shorten(value: string): string {
-  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-8)}` : value;
 }
 
 function relativeTime(iso: string): string {

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -248,14 +248,15 @@ export function DashboardActivityPage({
                         </div>
 
                         {/* Party */}
-                        <div className={styles.inlineCell}>
+                        <div className={cn(styles.inlineCell, styles.partyCell)}>
                           <span className={styles.prefix}>{sent ? "To" : "From"}</span>
                           <span className={styles.monoValue}>{counterparty}</span>
                           <CopyButton text={counterparty} />
                         </div>
 
                         {/* Ledger tx */}
-                        <div className={styles.inlineCell}>
+                        <div className={cn(styles.inlineCell, styles.txCell)}>
+                          <span className={cn(styles.prefix, styles.txPrefix)}>Tx</span>
                           {row.txId ? (
                             <>
                               <span className={styles.monoValue}>{shorten(row.txId)}</span>

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -247,11 +247,11 @@ export function DashboardActivityPage({
                           {amount}
                         </div>
 
-                        {/* Party */}
+                        {/* Party — the history API truncates party ids
+                            server-side, so there's no full value to copy. */}
                         <div className={cn(styles.inlineCell, styles.partyCell)}>
                           <span className={styles.prefix}>{sent ? "To" : "From"}</span>
                           <span className={styles.monoValue}>{counterparty}</span>
-                          <CopyButton text={counterparty} />
                         </div>
 
                         {/* Ledger tx */}

--- a/packages/dapp/src/pages/DashboardActivityPage.tsx
+++ b/packages/dapp/src/pages/DashboardActivityPage.tsx
@@ -4,23 +4,12 @@ import { useState, useEffect, useMemo } from "react";
 import { AmbientOrb } from "../components/AmbientOrb";
 import { DashboardLayout, type DashboardTab } from "../components/DashboardLayout";
 import { Spinner } from "../components/Spinner";
-import { NETWORK } from "../lib/config";
-import { getTokens, type TokenConfig } from "../lib/middleware";
-import {
-  getTransferLogs,
-  getTransactionReceipt,
-  formatTokenAmount,
-  type TransferLog,
-} from "../lib/ethrpc";
-import {
-  getPendingTxs,
-  removePendingTx,
-  markPendingFailed,
-  type PendingTx,
-} from "../lib/pendingTxs";
-import { TOKEN_COLORS } from "../lib/tokens";
-import { toChecksumAddress, shortenAddress } from "../lib/ethereum";
 import { CopyButton } from "../components/CopyButton";
+import { NETWORK } from "../lib/config";
+import { formatTokenAmount } from "../lib/ethrpc";
+import { listCompletedTransfers, type CompletedTransfer } from "../lib/transfer";
+import { TOKEN_COLORS } from "../lib/tokens";
+import { cn } from "../lib/cn";
 import styles from "./DashboardActivityPage.module.css";
 
 interface Props {
@@ -28,92 +17,23 @@ interface Props {
   activeTab: DashboardTab;
   onTabChange: (tab: DashboardTab) => void;
   onDisconnect: () => void;
+  /** The signed-in user's Canton party id — used to label rows Sent vs Received. */
+  cantonPartyId: string;
 }
 
-type RowStatus = "confirmed" | "pending" | "failed";
-
-interface ActivityRow extends TransferLog {
-  token: TokenConfig;
-  status: RowStatus;
-  revertReason?: string;
-}
-
-type FetchState =
-  | { url: string; address: string; rows: ActivityRow[]; error: null }
-  | { url: string; address: string; rows: null; error: string };
-
-const RECEIPT_POLL_INTERVAL_MS = 4000;
-
-function pendingToRow(p: PendingTx): ActivityRow {
-  return {
-    txHash: p.txHash,
-    // Pending entries have no block yet; sentinel keeps sort order (newest first).
-    blockNumber: Number.MAX_SAFE_INTEGER,
-    logIndex: 0,
-    timestamp: p.submittedAt,
-    direction: "sent",
-    tokenAddress: p.tokenAddress,
-    amount: BigInt(p.amount),
-    from: p.from,
-    to: p.to,
-    token: {
-      address: p.tokenAddress,
-      name: p.tokenSymbol,
-      symbol: p.tokenSymbol,
-      decimals: p.tokenDecimals,
-    },
-    status: p.status === "failed" ? "failed" : "pending",
-    revertReason: p.revertReason,
-  };
-}
-
-// Jan 1 2020 in Unix seconds — anything before this is a synthetic/bogus timestamp
-const MIN_REAL_TIMESTAMP = 1577836800;
-
-function relativeTime(ts: number): string {
-  if (!ts || ts < MIN_REAL_TIMESTAMP) return "—";
-  const diff = Date.now() / 1000 - ts;
-  if (diff < 60) return "just now";
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  if (diff < 172800) return "Yesterday";
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
-function timeLocal(ts: number): string {
-  if (!ts || ts < MIN_REAL_TIMESTAMP) return "";
-  // Render in the viewer's local timezone (timeZoneName shows the local
-  // abbreviation, e.g. EDT/GMT+1). Day grouping below also uses local time,
-  // so the time shown stays consistent with its day label.
-  return new Date(ts * 1000).toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    timeZoneName: "short",
-  });
-}
-
-function dayKey(ts: number): string {
-  if (!ts) return "unknown";
-  return new Date(ts * 1000).toDateString();
-}
-
-function dayLabel(ts: number): string {
-  if (!ts) return "UNKNOWN";
-  const d = new Date(ts * 1000);
-  const today = new Date();
-  const yesterday = new Date(today);
-  yesterday.setDate(today.getDate() - 1);
-  const month = d.toLocaleDateString("en-US", { month: "short", day: "numeric" }).toUpperCase();
-  if (d.toDateString() === today.toDateString()) return `TODAY · ${month}`;
-  if (d.toDateString() === yesterday.toDateString()) return `YESTERDAY · ${month}`;
-  return d
-    .toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
-    .toUpperCase();
+interface ActivityState {
+  url: string;
+  address: string;
+  rows: CompletedTransfer[];
+  total: number;
+  page: number;
+  hasMore: boolean;
+  error: string | null;
 }
 
 function ArrowUpIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+    <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
       <path
         d="M10 15V5M5 10L10 5L15 10"
         stroke="currentColor"
@@ -127,7 +47,7 @@ function ArrowUpIcon() {
 
 function ArrowDownIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+    <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
       <path
         d="M10 5V15M5 10L10 15L15 10"
         stroke="currentColor"
@@ -148,179 +68,90 @@ function TokenIcon({ symbol }: { symbol: string }) {
   );
 }
 
-function SearchIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M9.5 9.5L12 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  );
-}
+export function DashboardActivityPage({
+  address,
+  activeTab,
+  onTabChange,
+  onDisconnect,
+  cantonPartyId,
+}: Props) {
+  const [state, setState] = useState<ActivityState | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
-export function DashboardActivityPage({ address, activeTab, onTabChange, onDisconnect }: Props) {
-  const [fetchState, setFetchState] = useState<FetchState | null>(null);
-  const [search, setSearch] = useState("");
+  const loading = state?.url !== NETWORK.middlewareUrl || state?.address !== address;
 
-  // Bump to re-read the pending store (localStorage) or re-fetch confirmed logs.
-  // Pending is derived state, not local state — the source of truth is
-  // localStorage. Components that mutate the store (TransferPage, the polling
-  // callback below) write to localStorage, then we read it back here.
-  const [pendingTick, setPendingTick] = useState(0);
-  const [logsTick, setLogsTick] = useState(0);
-
-  const pending = useMemo(
-    () => getPendingTxs(address),
-    // pendingTick re-runs the read when the store mutates
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [address, pendingTick],
-  );
-
-  const loading = fetchState?.url !== NETWORK.middlewareUrl || fetchState?.address !== address;
-
+  // Load the first page of settled history for this address. Refetches from
+  // scratch when the address (or network) changes.
   useEffect(() => {
     let cancelled = false;
-    const rpcUrl = `${NETWORK.middlewareUrl}/eth`;
-
-    async function load() {
-      try {
-        const tokens = await getTokens(NETWORK.middlewareUrl);
-        const tokenByAddress = new Map(tokens.map((t) => [t.address.toLowerCase(), t]));
-        const logs = await getTransferLogs(
-          rpcUrl,
-          tokens.map((t) => t.address),
-          address,
-        );
-        const rows: ActivityRow[] = logs
-          .map((log): ActivityRow | null => {
-            const token = tokenByAddress.get(log.tokenAddress);
-            if (!token) return null;
-            return { ...log, token, status: "confirmed" };
-          })
-          .filter((r): r is ActivityRow => r !== null);
-
+    const url = NETWORK.middlewareUrl;
+    listCompletedTransfers(url, address, 1)
+      .then((p) => {
         if (cancelled) return;
-
-        // Drop pending entries whose confirmed Transfer log just arrived —
-        // covers reloads after the receipt landed and any poll the user
-        // missed because the tab was hidden.
-        const confirmedHashes = new Set(rows.map((r) => r.txHash.toLowerCase()));
-        let removed = false;
-        for (const p of getPendingTxs(address)) {
-          if (confirmedHashes.has(p.txHash.toLowerCase())) {
-            removePendingTx(address, p.txHash);
-            removed = true;
-          }
-        }
-
-        setFetchState({ url: NETWORK.middlewareUrl, address, rows, error: null });
-        if (removed) setPendingTick((t) => t + 1);
-      } catch (e: unknown) {
-        if (!cancelled)
-          setFetchState({
-            url: NETWORK.middlewareUrl,
-            address,
-            rows: null,
-            error: (e as Error).message,
-          });
-      }
-    }
-
-    void load();
+        setState({
+          url,
+          address,
+          rows: p.items,
+          total: p.total,
+          page: p.page,
+          hasMore: p.hasMore,
+          error: null,
+        });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setState({
+          url,
+          address,
+          rows: [],
+          total: 0,
+          page: 1,
+          hasMore: false,
+          error: (e as Error).message,
+        });
+      });
     return () => {
       cancelled = true;
     };
-  }, [address, logsTick]);
+  }, [address]);
 
-  // Poll receipts for entries still in "pending" status. Once a receipt arrives:
-  //   status=1 → remove (a confirmed log will appear on next refresh)
-  //   status=0 → mark failed and keep so the user sees the outcome
-  const hasUnresolved = pending.some((p) => p.status === "pending");
-
-  useEffect(() => {
-    if (!hasUnresolved) return;
-
-    const rpcUrl = `${NETWORK.middlewareUrl}/eth`;
-    let cancelled = false;
-
-    async function poll() {
-      const snapshot = getPendingTxs(address).filter((p) => p.status === "pending");
-      if (snapshot.length === 0) return;
-      const results = await Promise.all(
-        snapshot.map(async (p) => {
-          try {
-            return [p, await getTransactionReceipt(rpcUrl, p.txHash)] as const;
-          } catch {
-            return [p, null] as const;
-          }
-        }),
+  async function loadMore() {
+    if (!state || loadingMore || !state.hasMore) return;
+    setLoadingMore(true);
+    try {
+      const next = await listCompletedTransfers(NETWORK.middlewareUrl, address, state.page + 1);
+      setState((s) =>
+        s
+          ? {
+              ...s,
+              rows: [...s.rows, ...next.items],
+              page: next.page,
+              hasMore: next.hasMore,
+              total: next.total,
+            }
+          : s,
       );
-      if (cancelled) return;
-
-      let resolvedAny = false;
-      for (const [p, receipt] of results) {
-        if (!receipt) continue;
-        resolvedAny = true;
-        if (receipt.status === "success") {
-          removePendingTx(address, p.txHash);
-        } else {
-          markPendingFailed(address, p.txHash, receipt.revertReason);
-        }
-      }
-      if (resolvedAny) {
-        setPendingTick((t) => t + 1);
-        setLogsTick((t) => t + 1);
-      }
+    } catch {
+      // Leave the existing list in place; the user can retry Load more.
+    } finally {
+      setLoadingMore(false);
     }
+  }
 
-    void poll();
-    const id = window.setInterval(() => void poll(), RECEIPT_POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(id);
-    };
-  }, [hasUnresolved, address]);
+  const me = useMemo(() => truncateParty(cantonPartyId), [cantonPartyId]);
+  const rows = useMemo(() => state?.rows ?? [], [state]);
 
-  const merged = useMemo(() => {
-    const confirmed = fetchState?.rows ?? [];
-    const confirmedHashes = new Set(confirmed.map((r) => r.txHash.toLowerCase()));
-    const pendingRows = pending
-      .filter((p) => !confirmedHashes.has(p.txHash.toLowerCase()))
-      .map(pendingToRow);
-    // Sort by timestamp (newest first) so failed entries fall into their
-    // historical day group rather than always sorting to the top. Within the
-    // same block, logIndex breaks ties. blockNumber is a tertiary key for the
-    // rare case of two confirmed blocks sharing a timestamp.
-    return [...pendingRows, ...confirmed].sort(
-      (a, b) =>
-        b.timestamp - a.timestamp || b.blockNumber - a.blockNumber || b.logIndex - a.logIndex,
-    );
-  }, [fetchState, pending]);
-
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return merged;
-    return merged.filter(
-      (r) =>
-        r.txHash.toLowerCase().includes(q) ||
-        r.from.toLowerCase().includes(q) ||
-        r.to.toLowerCase().includes(q) ||
-        r.token.symbol.toLowerCase().includes(q),
-    );
-  }, [merged, search]);
-
-  // Group rows by calendar day. Only in-flight pending entries land in the
-  // dedicated PENDING group; failed entries fall into their submission-day
-  // group so the resolved-but-unsuccessful history stays chronological.
+  // Group rows by calendar day, preserving the server's newest-first order.
   const groups = useMemo(() => {
-    const map = new Map<string, ActivityRow[]>();
-    for (const row of filtered) {
-      const key = row.status === "pending" ? "__pending__" : dayKey(row.timestamp);
+    const map = new Map<string, CompletedTransfer[]>();
+    for (const row of rows) {
+      const key = dayKey(row.timestamp);
       const arr = map.get(key) ?? [];
       arr.push(row);
       map.set(key, arr);
     }
-    return [...map.entries()].map(([key, rows]) => ({ key, rows }));
-  }, [filtered]);
+    return [...map.entries()].map(([key, items]) => ({ key, items }));
+  }, [rows]);
 
   return (
     <>
@@ -331,34 +162,20 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
         onTabChange={onTabChange}
         onDisconnect={onDisconnect}
       >
-        {/* Header */}
         <div className={styles.pageHeader}>
-          <div className={styles.pageTitles}>
-            <h1 className={styles.pageTitle}>Activity</h1>
-            <p className={styles.pageSubtitle}>Token transfers for this wallet.</p>
-          </div>
-          <label className={styles.searchBar}>
-            <SearchIcon />
-            <input
-              className={styles.searchInput}
-              placeholder="Search by tx hash, address, or token…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-          </label>
+          <h1 className={styles.pageTitle}>Activity</h1>
+          <p className={styles.pageSubtitle}>Settled transfer history on Canton Network.</p>
         </div>
 
-        {/* Column headers */}
         <div className={styles.colHeaders}>
           <span>TYPE</span>
           <span>TOKEN</span>
           <span>AMOUNT</span>
-          <span>TO / FROM</span>
-          <span>TX HASH</span>
+          <span>PARTY</span>
+          <span>LEDGER TX</span>
           <span className={styles.colRight}>DATE</span>
         </div>
 
-        {/* Card */}
         <div className={styles.card}>
           {loading && (
             <div className={styles.centred}>
@@ -366,117 +183,93 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
             </div>
           )}
 
-          {!loading && fetchState?.error && (
+          {!loading && state?.error && (
             <div className={styles.centred}>
-              <p className={styles.errorText}>{fetchState.error}</p>
+              <p className={styles.errorText}>{state.error}</p>
             </div>
           )}
 
-          {!loading && fetchState?.rows && filtered.length === 0 && (
+          {!loading && state && !state.error && rows.length === 0 && (
             <div className={styles.centred}>
-              <p className={styles.hint}>
-                {search.trim()
-                  ? "No transfers match your search."
-                  : "No transfers found for this address."}
-              </p>
+              <p className={styles.hint}>No transfers yet for this party.</p>
             </div>
           )}
 
           {!loading &&
-            fetchState?.rows &&
-            filtered.length > 0 &&
-            groups.map(({ key, rows }) => (
+            state &&
+            !state.error &&
+            rows.length > 0 &&
+            groups.map(({ key, items }) => (
               <div key={key}>
-                <div className={styles.dayGroup}>
-                  {key === "__pending__" ? "PENDING" : dayLabel(rows[0].timestamp)}
-                </div>
-                {rows.map((row, i) => {
-                  const isSent = row.direction === "sent";
-                  const counterparty = toChecksumAddress(isSent ? row.to : row.from);
-                  const shortTx = `${row.txHash.slice(0, 10)}…${row.txHash.slice(-8)}`;
-                  const isPending = row.status === "pending";
-                  const isFailed = row.status === "failed";
-
+                <div className={styles.dayGroup}>{dayLabel(items[0].timestamp)}</div>
+                {items.map((row, i) => {
+                  const sent = row.fromPartyId === me;
+                  const counterparty = sent ? row.toPartyId : row.fromPartyId;
+                  const symbol = row.symbol ?? row.instrumentId;
+                  const amount =
+                    row.decimals !== undefined
+                      ? formatTokenAmount(
+                          parseAmountToBigInt(row.amount, row.decimals),
+                          row.decimals,
+                        )
+                      : row.amount;
                   return (
-                    <div key={`${row.txHash}-${row.logIndex}`}>
+                    <div key={row.contractId}>
                       {i > 0 && <div className={styles.rowDivider} />}
-                      <div
-                        className={`${styles.activityRow} ${isPending ? styles.rowPending : ""} ${isFailed ? styles.rowFailed : ""}`}
-                      >
+                      <div className={styles.activityRow}>
                         {/* Type */}
                         <div className={styles.typeCell}>
                           <div
-                            className={`${styles.typeIcon} ${isSent ? styles.iconSent : styles.iconReceived}`}
+                            className={cn(
+                              styles.typeIcon,
+                              sent ? styles.iconSent : styles.iconReceived,
+                            )}
                           >
-                            {isSent ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                            {sent ? <ArrowUpIcon /> : <ArrowDownIcon />}
                           </div>
-                          <div className={styles.typeStack}>
-                            <span className={styles.typeLabel}>{isSent ? "Sent" : "Received"}</span>
-                            {isPending && (
-                              <span className={`${styles.statusPill} ${styles.statusPillPending}`}>
-                                <span className={styles.statusDot} />
-                                Pending
-                              </span>
-                            )}
-                            {isFailed && (
-                              <span
-                                className={`${styles.statusPill} ${styles.statusPillFailed}`}
-                                title={row.revertReason}
-                              >
-                                Failed
-                              </span>
-                            )}
-                          </div>
+                          <span className={styles.typeLabel}>{sent ? "Sent" : "Received"}</span>
                         </div>
 
                         {/* Token */}
                         <div className={styles.tokenCell}>
-                          <TokenIcon symbol={row.token.symbol} />
-                          <span className={styles.tokenSymbol}>{row.token.symbol}</span>
+                          <TokenIcon symbol={symbol} />
+                          <span className={styles.tokenSymbol}>{symbol}</span>
                         </div>
 
                         {/* Amount */}
-                        <div className={styles.amountCell}>
-                          <span
-                            className={`${styles.amountValue} ${isSent ? styles.amountSent : styles.amountReceived}`}
-                          >
-                            {isSent ? "−" : "+"}
-                            {formatTokenAmount(row.amount, row.token.decimals)}
-                          </span>
+                        <div
+                          className={cn(
+                            styles.amountValue,
+                            sent ? styles.amountSent : styles.amountReceived,
+                          )}
+                        >
+                          {sent ? "−" : "+"}
+                          {amount}
                         </div>
 
-                        {/* To / From */}
-                        <div className={styles.addrCell}>
-                          <span className={styles.addrLabel}>{isSent ? "To" : "From"}</span>
-                          <div className={styles.addrRow}>
-                            <span className={styles.addrValue}>
-                              {shortenAddress(counterparty, 5)}
-                            </span>
-                            <CopyButton text={counterparty} />
-                          </div>
+                        {/* Party */}
+                        <div className={styles.inlineCell}>
+                          <span className={styles.prefix}>{sent ? "To" : "From"}</span>
+                          <span className={styles.monoValue}>{counterparty}</span>
+                          <CopyButton text={counterparty} />
                         </div>
 
-                        {/* Tx hash */}
-                        <div className={styles.addrCell}>
-                          <span className={styles.addrLabel}>Tx</span>
-                          <div className={styles.addrRow}>
-                            <span className={styles.addrValue}>{shortTx}</span>
-                            <CopyButton text={row.txHash} />
-                          </div>
+                        {/* Ledger tx */}
+                        <div className={styles.inlineCell}>
+                          {row.txId ? (
+                            <>
+                              <span className={styles.monoValue}>{shorten(row.txId)}</span>
+                              <CopyButton text={row.txId} />
+                            </>
+                          ) : (
+                            <span className={styles.muted}>—</span>
+                          )}
                         </div>
 
                         {/* Date */}
                         <div className={styles.whenCell}>
-                          <span className={styles.whenRelative}>{relativeTime(row.timestamp)}</span>
-                          <span className={styles.whenAbsolute}>
-                            {isPending
-                              ? "Awaiting receipt"
-                              : isFailed
-                                ? "Reverted"
-                                : row.timestamp >= MIN_REAL_TIMESTAMP
-                                  ? timeLocal(row.timestamp)
-                                  : `Block #${row.blockNumber}`}
-                          </span>
+                          {relativeTime(row.timestamp)} ·{" "}
+                          <span className={styles.whenAbs}>{timeLocal(row.timestamp)}</span>
                         </div>
                       </div>
                     </div>
@@ -485,15 +278,89 @@ export function DashboardActivityPage({ address, activeTab, onTabChange, onDisco
               </div>
             ))}
 
-          {!loading && fetchState?.rows && filtered.length > 0 && (
+          {!loading && state && !state.error && rows.length > 0 && (
             <div className={styles.footer}>
               <span className={styles.footerCount}>
-                Showing {filtered.length} transfer{filtered.length !== 1 ? "s" : ""}
+                Showing {rows.length} of {state.total} transfer{state.total !== 1 ? "s" : ""}
               </span>
+              {state.hasMore && (
+                <button
+                  className={styles.loadMore}
+                  onClick={() => void loadMore()}
+                  disabled={loadingMore}
+                >
+                  {loadingMore ? "Loading…" : "Load more"}
+                </button>
+              )}
             </div>
           )}
         </div>
       </DashboardLayout>
     </>
   );
+}
+
+// ── helpers ──
+
+// Mirrors the middleware's party-id truncation (head 8 + "…" + tail 8) so the
+// signed-in party matches the truncated `from`/`to` the API returns.
+function truncateParty(partyId: string): string {
+  const head = 8;
+  const tail = 8;
+  if (partyId.length <= head + tail + 1) return partyId;
+  return partyId.slice(0, head) + "…" + partyId.slice(-tail);
+}
+
+function shorten(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-8)}` : value;
+}
+
+function relativeTime(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "—";
+  const diff = (Date.now() - ts) / 1000;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 172800) return "Yesterday";
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function timeLocal(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  return new Date(ts).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+}
+
+function dayKey(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "unknown";
+  return new Date(ts).toDateString();
+}
+
+function dayLabel(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "UNKNOWN";
+  const d = new Date(ts);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const month = d.toLocaleDateString("en-US", { month: "short", day: "numeric" }).toUpperCase();
+  if (d.toDateString() === today.toDateString()) return `TODAY · ${month}`;
+  if (d.toDateString() === yesterday.toDateString()) return `YESTERDAY · ${month}`;
+  return d
+    .toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
+    .toUpperCase();
+}
+
+// Parse a decimal string ("12.5") into the smallest-unit bigint for `decimals`.
+function parseAmountToBigInt(amount: string, decimals: number): bigint {
+  const [whole, fracRaw = ""] = amount.split(".");
+  const frac = (fracRaw + "0".repeat(decimals)).slice(0, decimals);
+  const digits = (whole + frac).replace(/^0+(?=\d)/, "") || "0";
+  try {
+    return BigInt(digits);
+  } catch {
+    return 0n;
+  }
 }


### PR DESCRIPTION
## What

Rebuilds the **Activity** tab on the middleware transfer-history API (`GET /api/v2/transfer/completed`, merged on middleware `main`), replacing the old `eth_getLogs` implementation.

The history API returns a different shape, so the UI was redesigned to match it:

| Before (`eth_getLogs`) | Now (`/completed`) |
|---|---|
| EVM addresses | **Canton party ids** (truncated `8…8`) — "Party" column |
| eth tx hash (explorer-style) | **ledger `tx_id`** (no explorer link) |
| live pending / failed rows + receipt polling | **settled only** (`status:"completed"`) |
| direction from EVM addr | derived by matching the signed-in **party id** vs truncated `from`/`to` |
| block timestamp | RFC3339 `timestamp` |

## Changes

- **`lib/transfer.ts`** — `listCompletedTransfers(baseUrl, address, page, limit)` returning one page (`items`, `total`, `page`, `limit`, `hasMore`), plus the `CompletedTransfer` type.
- **`App.tsx`** — passes `profile.cantonPartyId` to the Activity page (needed to label Sent/Received).
- **`DashboardActivityPage`** — full rewrite:
  - **No filtering / search.** The endpoint exposes no token/direction/kind/date/status filters, and we don't filter client-side — the list renders the paginated history as returned.
  - **Compact single-line rows** (≈half the previous height); **Direct/Offer kind removed**.
  - Day grouping kept; **Load more** for pagination (`page`/`limit`, `has_more`).
  - Drops the `pendingTxs` + `eth_getTransactionReceipt` polling machinery — in-flight transfers now surface on the Transfer "Done" step and the Offers tab.

## History API — filtering options (for reference)

Server-side params on `/completed` are **only**: `address` (required), `page` (≥1), `limit` (1–200). `status` is hardcoded to `completed` (role = any). There are **no** server filters for token, direction, kind, or date range, and no client-side filtering is applied.

## Notes / self-review

- Sent/Received relies on the dapp truncating the signed-in party id with the **same** rule as the server (`head 8 + … + tail 8`) and matching it against `from_party_id`. If the middleware changes its truncation, this derivation must change with it.
- `tx_id` is a Canton ledger update id, shown truncated + copyable; intentionally **not** linked to a block explorer.
- Depends on `/api/v2/transfer/completed` being deployed; until then the tab shows its empty/error state. No automated tests in the dapp — verified via `tsc` / `eslint` / `vite build` and a local boot.
- `tsc`, `eslint`, `prettier`, `vite build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
